### PR TITLE
Fix Club Pro page navigation

### DIFF
--- a/client/src/pages/ClubPro.tsx
+++ b/client/src/pages/ClubPro.tsx
@@ -3,9 +3,11 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Search, Headphones, Building, Star, CheckCircle, ArrowRight, Users, TrendingUp, Award, CreditCard, Tag, Rocket, Shield, Crown, User, Zap, Target, Calendar, MessageSquare, Phone, Mail, MapPin, Clock, DollarSign, Percent, ArrowUpRight } from "lucide-react";
+import { useLocation } from "wouter";
 
 export default function ClubPro() {
   const { t } = useLanguage();
+  const [, setLocation] = useLocation();
 
   const features = [
     {
@@ -385,9 +387,13 @@ export default function ClubPro() {
               <ArrowRight className="w-5 h-5 ml-2" />
             </Button>
             
-            <Button variant="outline" className="bg-white text-orange-600 hover:bg-gray-100 px-8 py-4 text-lg font-semibold rounded-xl transition-all transform hover:scale-105 shadow-2xl">
-              En savoir plus
-            </Button>
+              <Button
+                variant="outline"
+                className="bg-white text-orange-600 hover:bg-gray-100 px-8 py-4 text-lg font-semibold rounded-xl transition-all transform hover:scale-105 shadow-2xl"
+                onClick={() => setLocation("/faq")}
+              >
+                En savoir plus
+              </Button>
           </div>
           
           <p className="text-sm text-orange-100 mt-6">


### PR DESCRIPTION
## Summary
- wire Club Pro page to wouter's router for navigation
- add FAQ link for "En savoir plus" button

## Testing
- `npm run check` *(fails: TypeScript errors in server/security and server/storage)*

------
https://chatgpt.com/codex/tasks/task_e_6897466848b88328a5f9ad356760b4a7