### PR TITLE
feat: use real user location

### DIFF
--- a/client/src/hooks/use-geolocation.ts
+++ b/client/src/hooks/use-geolocation.ts
@@ -21,7 +21,7 @@ export function useGeolocation() {
         // Vérifier si la géolocalisation est supportée
         if (!navigator.geolocation) {
           setState({
-            city: "Casablanca",
+            city: "",
             isLoading: false,
             error: "Géolocalisation non supportée",
           });
@@ -44,11 +44,11 @@ export function useGeolocation() {
               }
               
               const data = await response.json();
-              const city = data.address?.city || 
-                          data.address?.town || 
-                          data.address?.village || 
+              const city = data.address?.city ||
+                          data.address?.town ||
+                          data.address?.village ||
                           data.address?.municipality ||
-                          "Casablanca";
+                          "";
               
               setState({
                 city,
@@ -58,7 +58,7 @@ export function useGeolocation() {
             } catch (error) {
               console.error("Erreur géocodage:", error);
               setState({
-                city: "Casablanca",
+                city: "",
                 isLoading: false,
                 error: "Erreur lors de la détection de la ville",
               });
@@ -81,7 +81,7 @@ export function useGeolocation() {
             }
             
             setState({
-              city: "Casablanca",
+              city: "",
               isLoading: false,
               error: errorMessage,
             });
@@ -95,7 +95,7 @@ export function useGeolocation() {
       } catch (error) {
         console.error("Erreur détection localisation:", error);
         setState({
-          city: "Casablanca",
+          city: "",
           isLoading: false,
           error: "Erreur lors de la détection de la localisation",
         });


### PR DESCRIPTION
## Summary
- stop defaulting to Casablanca in geolocation hook
- derive user city via geolocation on index page without hardcoded fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Object literal may only specify known properties and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68974caf8eac8328a3f1f99ca9a7d028