### PR TITLE
Fix logout menu and profile navigation

### DIFF
--- a/client/src/components/ui/UserProfileMenu.tsx
+++ b/client/src/components/ui/UserProfileMenu.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { useLanguage } from "@/contexts/LanguageContext";
-import { Link } from "wouter";
+import { Link, useLocation } from "wouter";
 import { 
   User, 
   Package, 
@@ -33,6 +33,7 @@ export default function UserProfileMenu({ className = "" }: UserProfileMenuProps
   const [isOpen, setIsOpen] = useState(false);
   const [menuPosition, setMenuPosition] = useState<'right' | 'left'>('right');
   const menuRef = useRef<HTMLDivElement>(null);
+  const [, setLocation] = useLocation();
 
   // Données mockées de l'utilisateur
   const user = {
@@ -85,9 +86,12 @@ export default function UserProfileMenu({ className = "" }: UserProfileMenuProps
   };
 
   const handleLogout = () => {
-    // Logique de déconnexion
-    console.log("Déconnexion...");
+    // Suppression des données d'authentification
+    localStorage.removeItem('auth_token');
+    localStorage.removeItem('refresh_token');
+    localStorage.removeItem('user_data');
     setIsOpen(false);
+    setLocation('/login');
   };
 
   const menuItems = isClient ? [

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -57,6 +57,12 @@ const clientData = {
 export default function Profile() {
   const { t } = useLanguage();
   const [, setLocation] = useLocation();
+  const handleLogout = () => {
+    localStorage.removeItem('auth_token');
+    localStorage.removeItem('refresh_token');
+    localStorage.removeItem('user_data');
+    setLocation('/login');
+  };
 
   return (
     <div className="min-h-screen bg-gray-50 pt-20">
@@ -91,7 +97,7 @@ export default function Profile() {
               </div>
             </div>
             
-            {/* Badges et actions */}
+            {/* Badges */}
             <div className="flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-4">
               {clientData.isVerified && (
                 <div className="flex items-center space-x-1 bg-green-50 text-green-600 px-3 py-1 rounded-full text-sm font-medium">
@@ -99,17 +105,6 @@ export default function Profile() {
                   <span>Vérifié</span>
                 </div>
               )}
-              
-              <div className="flex space-x-2">
-                <Button 
-                  variant="outline" 
-                  size="sm"
-                  onClick={() => setLocation("/profile/info")}
-                >
-                  <Edit className="w-4 h-4 mr-2" />
-                  Modifier
-                </Button>
-              </div>
             </div>
           </div>
         </div>
@@ -214,37 +209,54 @@ export default function Profile() {
                   <h4 className="font-medium text-gray-900">Informations personnelles</h4>
                   <p className="text-sm text-gray-600">Nom, email, téléphone</p>
                 </div>
-                <Button variant="outline" size="sm">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setLocation('/profile/info')}
+                >
                   Modifier
                 </Button>
               </div>
-              
+
               <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
                 <div>
                   <h4 className="font-medium text-gray-900">Sécurité</h4>
                   <p className="text-sm text-gray-600">Mot de passe, authentification</p>
                 </div>
-                <Button variant="outline" size="sm">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setLocation('/profil/client/securite')}
+                >
                   Modifier
                 </Button>
               </div>
-              
+
               <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
                 <div>
                   <h4 className="font-medium text-gray-900">Notifications</h4>
                   <p className="text-sm text-gray-600">Préférences de notification</p>
                 </div>
-                <Button variant="outline" size="sm">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setLocation('/profil/client/notifications')}
+                >
                   Configurer
                 </Button>
               </div>
-              
+
               <div className="flex items-center justify-between p-4 bg-red-50 rounded-lg">
                 <div>
                   <h4 className="font-medium text-red-900">Déconnexion</h4>
                   <p className="text-sm text-red-600">Se déconnecter de votre compte</p>
                 </div>
-                <Button variant="outline" size="sm" className="text-red-600 border-red-200 hover:bg-red-50">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-red-600 border-red-200 hover:bg-red-50"
+                  onClick={handleLogout}
+                >
                   <LogOut className="w-4 h-4 mr-2" />
                   Déconnexion
                 </Button>


### PR DESCRIPTION
## Summary
- properly clear auth data and redirect on logout
- streamline profile page actions with navigation links

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check` (fails: Type '{ id: number; userId: number; specialties?: string[] | null | undefined; experien...`)


------
https://chatgpt.com/codex/tasks/task_e_68974fb6847c8328a2abdb74b995a137