### PR TITLE
feat: add arabic translations for key pages

### DIFF
--- a/client/src/contexts/LanguageContext.tsx
+++ b/client/src/contexts/LanguageContext.tsx
@@ -233,6 +233,13 @@ const translations = {
     "profile.menu.verification_desc": "Vérifiez votre identité",
     "profile.menu.payments": "Paiements",
     "profile.menu.payments_desc": "Moyens de paiement et facturation",
+
+    "profile.overview": "Aperçu",
+    "profile.completed_missions": "Missions terminées",
+    "profile.favorite_providers": "Prestataires favoris",
+    "profile.average_rating": "Note moyenne reçue",
+    "profile.reserved_missions": "Missions réservées",
+    "profile.reviews_received": "Avis reçus des prestataires",
     
     // Common
     "common.configure": "Configurer",
@@ -386,6 +393,57 @@ const translations = {
     "provider_profile.mission_placeholder": "Décrivez votre projet...",
     "provider_profile.cancel": "Annuler",
     "provider_profile.confirm": "Confirmer",
+
+    // Reservations page
+    "reservations.manage": "Gérez vos réservations et suivez l'état de vos services",
+    "reservations.filters.all": "Toutes",
+    "reservations.filters.pending": "En attente",
+    "reservations.filters.confirmed": "Confirmées",
+    "reservations.filters.completed": "Terminées",
+    "reservations.status.confirmed": "confirmée",
+    "reservations.status.pending": "en attente",
+    "reservations.status.completed": "terminée",
+    "reservations.contact": "Contacter",
+    "reservations.details": "Voir détails",
+    "reservations.empty.title": "Aucune réservation",
+    "reservations.empty.desc": "Vous n'avez pas encore de réservations. Commencez par rechercher un service !",
+    "reservations.empty.cta": "Rechercher un service",
+
+    // Favorites page
+    "favorites.description": "Vos prestataires préférés et les services que vous aimez",
+    "favorites.stats.total": "Total favoris",
+    "favorites.stats.online": "En ligne",
+    "favorites.stats.club_pro": "Club Pro",
+    "favorites.message": "Message",
+    "favorites.call": "Appeler",
+    "favorites.empty.title": "Aucun favori",
+    "favorites.empty.desc": "Vous n'avez pas encore ajouté de prestataires à vos favoris. Commencez par explorer nos services !",
+    "favorites.empty.cta": "Découvrir des prestataires",
+
+    // Messages page
+    "messages.search_placeholder": "Rechercher...",
+    "messages.just_now": "À l'instant",
+
+    // Settings page
+    "settings.title": "Réglages",
+    "settings.description": "Gérez vos préférences et paramètres de compte",
+    "settings.profile_section": "Profil et informations",
+    "settings.profile.personal": "Informations personnelles",
+    "settings.profile.avatar": "Avatar et photo",
+    "settings.profile.language": "Préférences de langue",
+    "settings.security_section": "Sécurité et accès",
+    "settings.security.password": "Mot de passe",
+    "settings.security.2fa": "Authentification à deux facteurs",
+    "settings.security.sessions": "Sessions actives",
+    "settings.notifications_section": "Notifications",
+    "settings.notifications.manage": "Paramètres de notifications",
+    "settings.notifications.email": "Email",
+    "settings.notifications.sms": "SMS",
+    "settings.notifications.push": "Notifications push",
+    "settings.theme.dark_mode": "Mode sombre",
+    "settings.actions.logout": "Se déconnecter",
+    "settings.actions.delete_account": "Supprimer le compte",
+    "settings.actions.export_data": "Exporter les données",
   },
   ar: {
     // Navigation
@@ -614,7 +672,14 @@ const translations = {
     "profile.menu.verification_desc": "تحقق من هويتك",
     "profile.menu.payments": "المدفوعات",
     "profile.menu.payments_desc": "وسائل الدفع والفواتير",
-    
+
+    "profile.overview": "نظرة عامة",
+    "profile.completed_missions": "المهام المنجزة",
+    "profile.favorite_providers": "المقدّمون المفضلون",
+    "profile.average_rating": "متوسط التقييم",
+    "profile.reserved_missions": "المهام المحجوزة",
+    "profile.reviews_received": "التقييمات المستلمة من مقدمي الخدمات",
+
     // Common
     "common.configure": "تكوين",
     "common.search": "بحث",
@@ -763,6 +828,57 @@ const translations = {
     "provider_profile.mission_placeholder": "صف مشروعك...",
     "provider_profile.cancel": "إلغاء",
     "provider_profile.confirm": "تأكيد",
+
+    // Reservations page
+    "reservations.manage": "قم بإدارة حجوزاتك وتتبع حالة خدماتك",
+    "reservations.filters.all": "الكل",
+    "reservations.filters.pending": "قيد الانتظار",
+    "reservations.filters.confirmed": "مؤكدة",
+    "reservations.filters.completed": "منتهية",
+    "reservations.status.confirmed": "مؤكدة",
+    "reservations.status.pending": "قيد الانتظار",
+    "reservations.status.completed": "منتهية",
+    "reservations.contact": "اتصل",
+    "reservations.details": "عرض التفاصيل",
+    "reservations.empty.title": "لا توجد حجوزات",
+    "reservations.empty.desc": "ليس لديك أي حجوزات بعد. ابدأ بالبحث عن خدمة!",
+    "reservations.empty.cta": "ابحث عن خدمة",
+
+    // Favorites page
+    "favorites.description": "مقدمو الخدمات المفضلون لديك والخدمات التي تحبها",
+    "favorites.stats.total": "إجمالي المفضلة",
+    "favorites.stats.online": "متصل",
+    "favorites.stats.club_pro": "نادي المحترفين",
+    "favorites.message": "رسالة",
+    "favorites.call": "اتصال",
+    "favorites.empty.title": "لا توجد مفضلة",
+    "favorites.empty.desc": "لم تقم بإضافة أي مقدمي خدمات إلى المفضلة بعد. ابدأ باستكشاف خدماتنا!",
+    "favorites.empty.cta": "اكتشف مقدمي الخدمات",
+
+    // Messages page
+    "messages.search_placeholder": "ابحث...",
+    "messages.just_now": "الآن",
+
+    // Settings page
+    "settings.title": "الإعدادات",
+    "settings.description": "إدارة تفضيلاتك وإعدادات الحساب",
+    "settings.profile_section": "الملف الشخصي والمعلومات",
+    "settings.profile.personal": "المعلومات الشخصية",
+    "settings.profile.avatar": "الصورة الرمزية والصورة",
+    "settings.profile.language": "تفضيلات اللغة",
+    "settings.security_section": "الأمان والوصول",
+    "settings.security.password": "كلمة المرور",
+    "settings.security.2fa": "المصادقة الثنائية",
+    "settings.security.sessions": "الجلسات النشطة",
+    "settings.notifications_section": "الإشعارات",
+    "settings.notifications.manage": "إعدادات الإشعارات",
+    "settings.notifications.email": "البريد الإلكتروني",
+    "settings.notifications.sms": "رسائل SMS",
+    "settings.notifications.push": "إشعارات دفع",
+    "settings.theme.dark_mode": "الوضع الداكن",
+    "settings.actions.logout": "تسجيل الخروج",
+    "settings.actions.delete_account": "حذف الحساب",
+    "settings.actions.export_data": "تصدير البيانات",
   },
 };
 

--- a/client/src/pages/ClubPro.tsx
+++ b/client/src/pages/ClubPro.tsx
@@ -12,28 +12,28 @@ export default function ClubPro() {
   const features = [
     {
       icon: Shield,
-      title: "Vérification Premium",
-      description: "Badge vérifié et profil certifié pour inspirer confiance",
-      color: "from-blue-500 to-blue-600"
+      titleKey: "club_pro.verification.title",
+      descKey: "club_pro.verification.desc",
+      color: "from-blue-500 to-blue-600",
     },
     {
       icon: TrendingUp,
-      title: "Visibilité Prioritaire",
-      description: "Apparaissez en premier dans les résultats de recherche",
-      color: "from-green-500 to-green-600"
+      titleKey: "club_pro.visibility.title",
+      descKey: "club_pro.visibility.desc",
+      color: "from-green-500 to-green-600",
     },
     {
       icon: Crown,
-      title: "Support Premium",
-      description: "Assistance dédiée et réponse en moins d'1 heure",
-      color: "from-purple-500 to-purple-600"
+      titleKey: "club_pro.trust.title",
+      descKey: "club_pro.trust.desc",
+      color: "from-purple-500 to-purple-600",
     },
     {
       icon: Zap,
-      title: "Accès Premium",
-      description: "Clients de qualité et projets exclusifs",
-      color: "from-orange-500 to-orange-600"
-    }
+      titleKey: "club_pro.exclusive_access",
+      descKey: "club_pro.large_projects",
+      color: "from-orange-500 to-orange-600",
+    },
   ];
 
   const benefits = [
@@ -120,32 +120,29 @@ export default function ClubPro() {
         <div className="relative max-w-7xl mx-auto px-4 text-center">
           <div className="inline-flex items-center space-x-3 bg-white/20 backdrop-blur-sm px-6 py-3 rounded-full mb-8 border border-white/30">
             <Crown className="w-5 h-5" />
-            <span className="font-bold text-lg">Club Pro</span>
+            <span className="font-bold text-lg">{t("nav.club_pro")}</span>
           </div>
-          
+
           <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
-            Rejoignez l'
-            <span className="bg-gradient-to-r from-yellow-300 to-yellow-100 bg-clip-text text-transparent">
-              Élite
-            </span>
+            {t("club_pro.title")}
           </h1>
-          
+
           <p className="text-xl md:text-2xl text-orange-100 max-w-4xl mx-auto leading-relaxed mb-12">
-            Développez votre activité, gagnez la confiance des clients et accédez à de nouveaux projets avec notre plateforme de confiance
+            {t("club_pro.join_elite")}
           </p>
           
           <div className="flex flex-wrap items-center justify-center gap-6 text-orange-100 text-sm mb-12">
             <div className="flex items-center space-x-2 bg-white/10 px-4 py-2 rounded-full">
               <CheckCircle className="w-5 h-5" />
-              <span>Vérification 24h</span>
+              <span>{t("club_pro.verification_24h")}</span>
             </div>
             <div className="flex items-center space-x-2 bg-white/10 px-4 py-2 rounded-full">
               <CheckCircle className="w-5 h-5" />
-              <span>Support prioritaire</span>
+              <span>{t("club_pro.priority_support")}</span>
             </div>
             <div className="flex items-center space-x-2 bg-white/10 px-4 py-2 rounded-full">
               <CheckCircle className="w-5 h-5" />
-              <span>Badge premium</span>
+              <span>{t("club_pro.premium_badge")}</span>
             </div>
           </div>
 
@@ -154,7 +151,7 @@ export default function ClubPro() {
             className="bg-white text-orange-600 hover:bg-gray-100 px-8 py-4 text-lg font-semibold rounded-xl transition-all transform hover:scale-105 shadow-2xl"
             onClick={() => setLocation("/club-pro/checkout")}
           >
-            Rejoindre le Club Pro
+            {t("club_pro.join_button")}
             <ArrowRight className="w-5 h-5 ml-2" />
           </Button>
         </div>
@@ -185,10 +182,10 @@ export default function ClubPro() {
         <div className="max-w-7xl mx-auto px-4">
           <div className="text-center mb-16">
             <h2 className="text-4xl md:text-5xl font-bold text-gray-900 mb-6">
-              Pourquoi choisir le Club Pro ?
+              {t("club_pro.why_choose")}
             </h2>
             <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              Rejoignez l'élite des prestataires et bénéficiez d'avantages exclusifs
+              {t("club_pro.join_elite")}
             </p>
           </div>
           
@@ -202,10 +199,10 @@ export default function ClubPro() {
                       <Icon className="w-8 h-8 text-white" />
                     </div>
                     <h3 className="text-xl font-bold text-gray-900 mb-4">
-                      {feature.title}
+                      {t(feature.titleKey)}
                     </h3>
                     <p className="text-gray-600 leading-relaxed">
-                      {feature.description}
+                      {t(feature.descKey)}
                     </p>
                   </CardContent>
                 </Card>

--- a/client/src/pages/MesFavoris.tsx
+++ b/client/src/pages/MesFavoris.tsx
@@ -61,7 +61,7 @@ export default function MesFavoris() {
             {t("profile.menu.favorites")}
           </h1>
           <p className="text-gray-600">
-            Vos prestataires préférés et les services que vous aimez
+            {t("favorites.description")}
           </p>
         </div>
 
@@ -74,7 +74,7 @@ export default function MesFavoris() {
                   <Heart className="w-5 h-5 text-orange-600" />
                 </div>
                 <div>
-                  <p className="text-sm text-gray-600">Total favoris</p>
+                  <p className="text-sm text-gray-600">{t("favorites.stats.total")}</p>
                   <p className="text-2xl font-bold text-gray-900">{favorites.length}</p>
                 </div>
               </div>
@@ -88,7 +88,7 @@ export default function MesFavoris() {
                   <User className="w-5 h-5 text-green-600" />
                 </div>
                 <div>
-                  <p className="text-sm text-gray-600">En ligne</p>
+                  <p className="text-sm text-gray-600">{t("favorites.stats.online")}</p>
                   <p className="text-2xl font-bold text-gray-900">
                     {favorites.filter(f => f.isOnline).length}
                   </p>
@@ -104,7 +104,7 @@ export default function MesFavoris() {
                   <Crown className="w-5 h-5 text-purple-600" />
                 </div>
                 <div>
-                  <p className="text-sm text-gray-600">Club Pro</p>
+                  <p className="text-sm text-gray-600">{t("favorites.stats.club_pro")}</p>
                   <p className="text-2xl font-bold text-gray-900">
                     {favorites.filter(f => f.isClubPro).length}
                   </p>
@@ -176,15 +176,15 @@ export default function MesFavoris() {
                       onClick={() => setLocation(`/messages/${favorite.id}`)}
                     >
                       <MessageCircle className="w-4 h-4 mr-2" />
-                      Message
+                      {t("favorites.message")}
                     </Button>
-                    <Button 
-                      size="sm" 
+                    <Button
+                      size="sm"
                       className="flex-1"
                       onClick={() => window.open(`tel:${favorite.phone}`)}
                     >
                       <Phone className="w-4 h-4 mr-2" />
-                      Appeler
+                      {t("favorites.call")}
                     </Button>
                   </div>
                 </div>
@@ -200,14 +200,13 @@ export default function MesFavoris() {
               <Heart className="w-8 h-8 text-gray-400" />
             </div>
             <h3 className="text-lg font-semibold text-gray-900 mb-2">
-              Aucun favori
+              {t("favorites.empty.title")}
             </h3>
             <p className="text-gray-600 mb-4">
-              Vous n'avez pas encore ajouté de prestataires à vos favoris. 
-              Commencez par explorer nos services !
+              {t("favorites.empty.desc")}
             </p>
             <Button>
-              Découvrir des prestataires
+              {t("favorites.empty.cta")}
             </Button>
           </div>
         )}

--- a/client/src/pages/MesReservations.tsx
+++ b/client/src/pages/MesReservations.tsx
@@ -59,6 +59,19 @@ export default function MesReservations() {
     }
   };
 
+  const translateStatus = (status: string) => {
+    switch (status) {
+      case "confirmée":
+        return t("reservations.status.confirmed");
+      case "en attente":
+        return t("reservations.status.pending");
+      case "terminée":
+        return t("reservations.status.completed");
+      default:
+        return status;
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gray-50 pt-20">
       <div className="max-w-7xl mx-auto px-4 py-8">
@@ -68,23 +81,23 @@ export default function MesReservations() {
             {t("profile.menu.reservations")}
           </h1>
           <p className="text-gray-600">
-            Gérez vos réservations et suivez l'état de vos services
+            {t("reservations.manage")}
           </p>
         </div>
 
         {/* Filtres */}
         <div className="mb-6 flex flex-wrap gap-2">
           <Badge variant="secondary" className="cursor-pointer">
-            Toutes
+            {t("reservations.filters.all")}
           </Badge>
           <Badge variant="outline" className="cursor-pointer">
-            En attente
+            {t("reservations.filters.pending")}
           </Badge>
           <Badge variant="outline" className="cursor-pointer">
-            Confirmées
+            {t("reservations.filters.confirmed")}
           </Badge>
           <Badge variant="outline" className="cursor-pointer">
-            Terminées
+            {t("reservations.filters.completed")}
           </Badge>
         </div>
 
@@ -105,7 +118,7 @@ export default function MesReservations() {
                   </div>
                   <div className="flex items-center gap-2">
                     <Badge className={getStatusColor(reservation.status)}>
-                      {reservation.status}
+                      {translateStatus(reservation.status)}
                     </Badge>
                     <div className="flex items-center gap-1">
                       <Star className="w-4 h-4 text-yellow-400 fill-current" />
@@ -143,14 +156,14 @@ export default function MesReservations() {
                       onClick={() => setLocation(`/messages/${reservation.provider}`)}
                     >
                       <MessageCircle className="w-4 h-4 mr-2" />
-                      Contacter
+                      {t("reservations.contact")}
                     </Button>
-                    <Button 
+                    <Button
                       size="sm"
                       onClick={() => setLocation(`/reservations/${reservation.id}`)}
                     >
                       <Eye className="w-4 h-4 mr-2" />
-                      Voir détails
+                      {t("reservations.details")}
                     </Button>
                   </div>
                 </div>
@@ -166,13 +179,13 @@ export default function MesReservations() {
               <Calendar className="w-8 h-8 text-gray-400" />
             </div>
             <h3 className="text-lg font-semibold text-gray-900 mb-2">
-              Aucune réservation
+              {t("reservations.empty.title")}
             </h3>
             <p className="text-gray-600 mb-4">
-              Vous n'avez pas encore de réservations. Commencez par rechercher un service !
+              {t("reservations.empty.desc")}
             </p>
             <Button>
-              Rechercher un service
+              {t("reservations.empty.cta")}
             </Button>
           </div>
         )}

--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -176,7 +176,7 @@ export default function Messages() {
 
     if (days > 0) return `${days}j`;
     if (hours > 0) return `${hours}h`;
-    return "À l'instant";
+    return t("messages.just_now");
   };
 
   const filteredConversations = conversations.filter(conv =>
@@ -196,7 +196,7 @@ export default function Messages() {
             {/* Header */}
             <div className="p-4 border-b border-gray-200 bg-gray-50">
               <div className="flex items-center justify-between mb-4">
-                <h1 className="text-xl font-bold text-gray-900">Messages</h1>
+                <h1 className="text-xl font-bold text-gray-900">{t("messages.title")}</h1>
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button variant="ghost" size="sm" className="p-2">
@@ -226,7 +226,7 @@ export default function Messages() {
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
                 <input
                   type="text"
-                  placeholder="Rechercher une conversation..."
+                  placeholder={t("messages.search_placeholder")}
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   className="w-full pl-10 pr-4 py-2 border border-gray-200 rounded-lg focus:outline-none focus:border-orange-300"
@@ -467,7 +467,7 @@ export default function Messages() {
                     <div className="flex-1 relative">
                       <input
                         type="text"
-                        placeholder="Tapez votre message..."
+                        placeholder={t("chat.input_placeholder")}
                         value={newMessage}
                         onChange={(e) => setNewMessage(e.target.value)}
                         onKeyPress={(e) => e.key === 'Enter' && handleSendMessage()}

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -102,7 +102,7 @@ export default function Profile() {
               {clientData.isVerified && (
                 <div className="flex items-center space-x-1 bg-green-50 text-green-600 px-3 py-1 rounded-full text-sm font-medium">
                   <CheckCircle className="w-4 h-4" />
-                  <span>Vérifié</span>
+                  <span>{t("profile.verified")}</span>
                 </div>
               )}
             </div>
@@ -113,14 +113,14 @@ export default function Profile() {
         <div className="space-y-8">
           {/* Section Aperçu */}
           <div className="bg-white rounded-2xl shadow-lg p-6">
-            <h2 className="text-2xl font-bold text-gray-900 mb-6">Aperçu</h2>
+            <h2 className="text-2xl font-bold text-gray-900 mb-6">{t("profile.overview")}</h2>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
               <Card>
                 <CardContent className="p-6 text-center">
                   <div className="text-3xl font-bold text-orange-500 mb-2">
                     {clientData.completedMissions}
                   </div>
-                  <div className="text-sm text-gray-600">Missions terminées</div>
+                  <div className="text-sm text-gray-600">{t("profile.completed_missions")}</div>
                 </CardContent>
               </Card>
               
@@ -129,7 +129,7 @@ export default function Profile() {
                   <div className="text-3xl font-bold text-orange-500 mb-2">
                     {clientData.favoriteProviders}
                   </div>
-                  <div className="text-sm text-gray-600">Prestataires favoris</div>
+                  <div className="text-sm text-gray-600">{t("profile.favorite_providers")}</div>
                 </CardContent>
               </Card>
               
@@ -138,7 +138,7 @@ export default function Profile() {
                   <div className="text-3xl font-bold text-orange-500 mb-2">
                     {clientData.rating}
                   </div>
-                  <div className="text-sm text-gray-600">Note moyenne reçue</div>
+                  <div className="text-sm text-gray-600">{t("profile.average_rating")}</div>
                 </CardContent>
               </Card>
             </div>
@@ -146,7 +146,7 @@ export default function Profile() {
 
           {/* Section Missions */}
           <div className="bg-white rounded-2xl shadow-lg p-6">
-            <h2 className="text-2xl font-bold text-gray-900 mb-6">Missions réservées</h2>
+            <h2 className="text-2xl font-bold text-gray-900 mb-6">{t("profile.reserved_missions")}</h2>
             <div className="space-y-4">
               {clientData.missions.map((mission) => (
                 <Card key={mission.id}>
@@ -176,7 +176,7 @@ export default function Profile() {
 
           {/* Section Avis */}
           <div className="bg-white rounded-2xl shadow-lg p-6">
-            <h2 className="text-2xl font-bold text-gray-900 mb-6">Avis reçus des prestataires</h2>
+            <h2 className="text-2xl font-bold text-gray-900 mb-6">{t("profile.reviews_received")}</h2>
             <div className="space-y-4">
               {clientData.reviews.map((review) => (
                 <Card key={review.id}>

--- a/client/src/pages/Reglages.tsx
+++ b/client/src/pages/Reglages.tsx
@@ -54,10 +54,10 @@ export default function Reglages() {
         {/* Header */}
         <div className="mb-8">
           <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-2">
-            Réglages
+            {t("settings.title")}
           </h1>
           <p className="text-gray-600">
-            Gérez vos préférences et paramètres de compte
+            {t("settings.description")}
           </p>
         </div>
 
@@ -67,49 +67,49 @@ export default function Reglages() {
             <CardHeader>
               <CardTitle className="flex items-center space-x-2">
                 <User className="w-5 h-5 text-orange-600" />
-                <span>Profil et informations</span>
+                <span>{t("settings.profile_section")}</span>
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="flex items-center justify-between py-3 border-b border-gray-100">
                 <div>
-                  <h3 className="font-medium text-gray-900">Informations personnelles</h3>
+                  <h3 className="font-medium text-gray-900">{t("settings.profile.personal")}</h3>
                   <p className="text-sm text-gray-500">Nom, email, téléphone, localisation</p>
                 </div>
-                <Button 
-                  variant="ghost" 
+                <Button
+                  variant="ghost"
                   size="sm"
                   onClick={() => setLocation("/profile/info")}
                   className="text-orange-500 hover:text-orange-600"
                 >
-                  Modifier
+                  {t("common.configure")}
                   <ArrowRight className="w-4 h-4 ml-2" />
                 </Button>
               </div>
-              
+
               <div className="flex items-center justify-between py-3 border-b border-gray-100">
                 <div>
-                  <h3 className="font-medium text-gray-900">Avatar et photo</h3>
+                  <h3 className="font-medium text-gray-900">{t("settings.profile.avatar")}</h3>
                   <p className="text-sm text-gray-500">Changer votre photo de profil</p>
                 </div>
-                <Button 
-                  variant="ghost" 
+                <Button
+                  variant="ghost"
                   size="sm"
                   onClick={() => setLocation("/profile/info")}
                   className="text-orange-500 hover:text-orange-600"
                 >
-                  Modifier
+                  {t("common.configure")}
                   <ArrowRight className="w-4 h-4 ml-2" />
                 </Button>
               </div>
-              
+
               <div className="flex items-center justify-between py-3">
                 <div>
-                  <h3 className="font-medium text-gray-900">Préférences de langue</h3>
+                  <h3 className="font-medium text-gray-900">{t("settings.profile.language")}</h3>
                   <p className="text-sm text-gray-500">Français / العربية</p>
                 </div>
-                <Button 
-                  variant="ghost" 
+                <Button
+                  variant="ghost"
                   size="sm"
                   onClick={toggleLanguage}
                   className="text-orange-500 hover:text-orange-600"
@@ -126,54 +126,54 @@ export default function Reglages() {
             <CardHeader>
               <CardTitle className="flex items-center space-x-2">
                 <Shield className="w-5 h-5 text-orange-600" />
-                <span>Sécurité et accès</span>
+                <span>{t("settings.security_section")}</span>
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="flex items-center justify-between py-3 border-b border-gray-100">
                 <div>
-                  <h3 className="font-medium text-gray-900">Mot de passe</h3>
+                  <h3 className="font-medium text-gray-900">{t("settings.security.password")}</h3>
                   <p className="text-sm text-gray-500">Changer votre mot de passe</p>
                 </div>
-                <Button 
-                  variant="ghost" 
+                <Button
+                  variant="ghost"
                   size="sm"
                   onClick={() => setLocation("/profil/client/securite")}
                   className="text-orange-500 hover:text-orange-600"
                 >
-                  Modifier
+                  {t("common.configure")}
                   <ArrowRight className="w-4 h-4 ml-2" />
                 </Button>
               </div>
-              
+
               <div className="flex items-center justify-between py-3 border-b border-gray-100">
                 <div>
-                  <h3 className="font-medium text-gray-900">Authentification à deux facteurs</h3>
+                  <h3 className="font-medium text-gray-900">{t("settings.security.2fa")}</h3>
                   <p className="text-sm text-gray-500">Sécurisez votre compte</p>
                 </div>
-                <Button 
-                  variant="ghost" 
+                <Button
+                  variant="ghost"
                   size="sm"
                   onClick={() => setLocation("/profil/client/securite")}
                   className="text-orange-500 hover:text-orange-600"
                 >
-                  Configurer
+                  {t("common.configure")}
                   <ArrowRight className="w-4 h-4 ml-2" />
                 </Button>
               </div>
-              
+
               <div className="flex items-center justify-between py-3">
                 <div>
-                  <h3 className="font-medium text-gray-900">Sessions actives</h3>
+                  <h3 className="font-medium text-gray-900">{t("settings.security.sessions")}</h3>
                   <p className="text-sm text-gray-500">Gérer vos connexions</p>
                 </div>
-                <Button 
-                  variant="ghost" 
+                <Button
+                  variant="ghost"
                   size="sm"
                   onClick={() => setLocation("/profil/client/securite")}
                   className="text-orange-500 hover:text-orange-600"
                 >
-                  Voir
+                  {t("common.configure")}
                   <ArrowRight className="w-4 h-4 ml-2" />
                 </Button>
               </div>
@@ -185,29 +185,29 @@ export default function Reglages() {
             <CardHeader>
               <CardTitle className="flex items-center space-x-2">
                 <Bell className="w-5 h-5 text-orange-600" />
-                <span>Notifications</span>
+                <span>{t("settings.notifications_section")}</span>
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="flex items-center justify-between py-3 border-b border-gray-100">
                 <div>
-                  <h3 className="font-medium text-gray-900">Paramètres de notifications</h3>
+                  <h3 className="font-medium text-gray-900">{t("settings.notifications.manage")}</h3>
                   <p className="text-sm text-gray-500">Email, SMS, push notifications</p>
                 </div>
-                <Button 
-                  variant="ghost" 
+                <Button
+                  variant="ghost"
                   size="sm"
                   onClick={() => setLocation("/profil/client/notifications")}
                   className="text-orange-500 hover:text-orange-600"
                 >
-                  Configurer
+                  {t("common.configure")}
                   <ArrowRight className="w-4 h-4 ml-2" />
                 </Button>
               </div>
-              
+
               <div className="flex items-center justify-between py-3">
                 <div>
-                  <h3 className="font-medium text-gray-900">Mode sombre</h3>
+                  <h3 className="font-medium text-gray-900">{t("settings.theme.dark_mode")}</h3>
                   <p className="text-sm text-gray-500">Activer le thème sombre</p>
                 </div>
                 <Switch
@@ -309,55 +309,55 @@ export default function Reglages() {
             <CardHeader>
               <CardTitle className="flex items-center space-x-2">
                 <Settings className="w-5 h-5 text-orange-600" />
-                <span>Gestion du compte</span>
+                <span>{t("profile.account_settings")}</span>
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="flex items-center justify-between py-3 border-b border-gray-100">
                 <div>
-                  <h3 className="font-medium text-gray-900">Exporter mes données</h3>
+                  <h3 className="font-medium text-gray-900">{t("settings.actions.export_data")}</h3>
                   <p className="text-sm text-gray-500">Télécharger vos informations</p>
                 </div>
-                <Button 
-                  variant="ghost" 
+                <Button
+                  variant="ghost"
                   size="sm"
                   onClick={handleExportData}
                   className="text-orange-500 hover:text-orange-600"
                 >
                   <Download className="w-4 h-4 mr-2" />
-                  Exporter
+                  {t("settings.actions.export_data")}
                 </Button>
               </div>
-              
+
               <div className="flex items-center justify-between py-3 border-b border-gray-100">
                 <div>
-                  <h3 className="font-medium text-gray-900">Se déconnecter</h3>
+                  <h3 className="font-medium text-gray-900">{t("settings.actions.logout")}</h3>
                   <p className="text-sm text-gray-500">Fermer votre session</p>
                 </div>
-                <Button 
-                  variant="ghost" 
+                <Button
+                  variant="ghost"
                   size="sm"
                   onClick={handleLogout}
                   className="text-red-500 hover:text-red-600"
                 >
                   <LogOut className="w-4 h-4 mr-2" />
-                  Déconnexion
+                  {t("settings.actions.logout")}
                 </Button>
               </div>
-              
+
               <div className="flex items-center justify-between py-3">
                 <div>
-                  <h3 className="font-medium text-gray-900">Supprimer mon compte</h3>
+                  <h3 className="font-medium text-gray-900">{t("settings.actions.delete_account")}</h3>
                   <p className="text-sm text-gray-500">Action irréversible</p>
                 </div>
-                <Button 
-                  variant="ghost" 
+                <Button
+                  variant="ghost"
                   size="sm"
                   onClick={handleDeleteAccount}
                   className="text-red-500 hover:text-red-600"
                 >
                   <Trash2 className="w-4 h-4 mr-2" />
-                  Supprimer
+                  {t("settings.actions.delete_account")}
                 </Button>
               </div>
             </CardContent>


### PR DESCRIPTION
## Summary
- translate Club Pro page using i18n keys
- internationalize reservations, favorites, messages, profile and settings pages
- expand language context with missing French and Arabic strings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Type errors in server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68975683a41483288de679677ba6b371