### PR TITLE
feat: improve home layout and rtl support

### DIFF
--- a/client/src/components/providers/ArtisanProfileCard.tsx
+++ b/client/src/components/providers/ArtisanProfileCard.tsx
@@ -34,12 +34,14 @@ export default function ArtisanProfileCard({ provider }: ArtisanProfileCardProps
           <div className="bg-white rounded-2xl p-6 shadow-lg border border-gray-100 hover:shadow-xl transition-all duration-300 min-h-[320px] flex flex-col">
       <div className="flex items-start justify-between mb-2">
         <div className="flex items-center space-x-3 rtl:space-x-reverse">
-          <div className="w-14 h-14 bg-gradient-to-br from-orange-400 to-orange-600 rounded-full flex items-center justify-center text-white font-bold text-lg relative">
+          <div className="w-14 h-14 aspect-square bg-gradient-to-br from-orange-400 to-orange-600 rounded-full flex items-center justify-center text-white font-bold text-lg relative overflow-hidden">
             {provider.avatar ? (
               <img
                 src={provider.avatar}
                 alt={provider.name}
-                className="w-14 h-14 rounded-full object-cover"
+                className="w-full h-full object-cover"
+                loading="lazy"
+                decoding="async"
               />
             ) : (
               <User className="w-7 h-7" />

--- a/client/src/components/providers/FeaturedProviderCard.tsx
+++ b/client/src/components/providers/FeaturedProviderCard.tsx
@@ -36,12 +36,14 @@ export default function FeaturedProviderCard({ provider }: FeaturedProviderCardP
       <div className="bg-gradient-to-r from-orange-50 to-yellow-50 rounded-xl p-3 mb-3 border border-orange-100">
         <div className="flex items-start justify-between">
           <div className="flex items-center space-x-3">
-            <div className="w-12 h-12 bg-gradient-to-br from-orange-400 to-orange-600 rounded-full flex items-center justify-center text-white font-bold text-lg relative">
+            <div className="w-12 h-12 aspect-square bg-gradient-to-br from-orange-400 to-orange-600 rounded-full flex items-center justify-center text-white font-bold text-lg relative overflow-hidden">
               {provider.avatar ? (
-                <img 
-                  src={provider.avatar} 
+                <img
+                  src={provider.avatar}
                   alt={provider.name}
-                  className="w-12 h-12 rounded-full object-cover"
+                  className="w-full h-full object-cover"
+                  loading="lazy"
+                  decoding="async"
                 />
               ) : (
                 <User className="w-6 h-6" />

--- a/client/src/components/providers/FeaturedProvidersCarousel.tsx
+++ b/client/src/components/providers/FeaturedProvidersCarousel.tsx
@@ -388,7 +388,7 @@ export default function FeaturedProvidersCarousel({ className = "" }: FeaturedPr
             className="absolute left-0 top-1/2 -translate-y-1/2 z-10 bg-white border border-orange-200 rounded-full p-3 shadow-lg hover:bg-orange-50 disabled:opacity-30 disabled:cursor-not-allowed transition-all duration-200 -ml-4 md:-ml-6"
             aria-label="Précédent"
           >
-            <ChevronLeft aria-hidden="true" focusable="false" className="w-5 h-5 text-orange-500" />
+            <ChevronLeft aria-hidden="true" focusable="false" className="w-5 h-5 text-orange-500 rtl:rotate-180" />
           </button>
 
           <button
@@ -397,7 +397,7 @@ export default function FeaturedProvidersCarousel({ className = "" }: FeaturedPr
             className="absolute right-0 top-1/2 -translate-y-1/2 z-10 bg-white border border-orange-200 rounded-full p-3 shadow-lg hover:bg-orange-50 disabled:opacity-30 disabled:cursor-not-allowed transition-all duration-200 -mr-4 md:-mr-6"
             aria-label="Suivant"
           >
-            <ChevronRight aria-hidden="true" focusable="false" className="w-5 h-5 text-orange-500" />
+            <ChevronRight aria-hidden="true" focusable="false" className="w-5 h-5 text-orange-500 rtl:rotate-180" />
           </button>
 
           {/* Conteneur des prestataires */}

--- a/client/src/components/providers/JoinProviders.tsx
+++ b/client/src/components/providers/JoinProviders.tsx
@@ -9,7 +9,7 @@ export default function JoinProviders() {
     <section className="py-16 bg-gradient-to-br from-orange-500 to-orange-600 text-white w-full">
       <div className="max-w-7xl mx-auto px-4 md:px-6">
         <div className="text-center mb-12">
-          <div className="w-20 h-20 bg-white/20 rounded-2xl flex items-center justify-center mx-auto mb-6">
+          <div className="w-20 h-20 aspect-square bg-white/20 rounded-2xl flex items-center justify-center mx-auto mb-6">
             <Users className="w-10 h-10" />
           </div>
           
@@ -27,7 +27,7 @@ export default function JoinProviders() {
           <Link href="/register">
             <button  className="bg-white text-orange-600 hover:bg-orange-50 px-8 py-4 rounded-xl font-semibold text-lg transition-all flex items-center space-x-2 shadow-lg hover:shadow-xl">
               <span>{t("join_providers.become_provider")}</span>
-              <ArrowRight className="w-5 h-5" />
+              <ArrowRight className="w-5 h-5 rtl:rotate-180" />
             </button>
           </Link>
           
@@ -40,9 +40,9 @@ export default function JoinProviders() {
         </div>
 
         {/* Avantages */}
-        <div className="grid md:grid-cols-3 gap-8 mt-16">
+          <div className="grid md:grid-cols-3 gap-8 mt-16">
           <div className="text-center">
-            <div className="w-16 h-16 bg-white/20 rounded-xl flex items-center justify-center mx-auto mb-4">
+            <div className="w-16 h-16 aspect-square bg-white/20 rounded-xl flex items-center justify-center mx-auto mb-4">
               <span className="text-2xl">🚀</span>
             </div>
             <h3 className="text-xl font-bold mb-2">{t("join_providers.develop_activity_title")}</h3>
@@ -50,7 +50,7 @@ export default function JoinProviders() {
           </div>
           
           <div className="text-center">
-            <div className="w-16 h-16 bg-white/20 rounded-xl flex items-center justify-center mx-auto mb-4">
+            <div className="w-16 h-16 aspect-square bg-white/20 rounded-xl flex items-center justify-center mx-auto mb-4">
               <span className="text-2xl">✅</span>
             </div>
             <h3 className="text-xl font-bold mb-2">{t("join_providers.gain_trust_title")}</h3>
@@ -58,7 +58,7 @@ export default function JoinProviders() {
           </div>
           
           <div className="text-center">
-            <div className="w-16 h-16 bg-white/20 rounded-xl flex items-center justify-center mx-auto mb-4">
+            <div className="w-16 h-16 aspect-square bg-white/20 rounded-xl flex items-center justify-center mx-auto mb-4">
               <span className="text-2xl">💰</span>
             </div>
             <h3 className="text-xl font-bold mb-2">{t("join_providers.competitive_prices_title")}</h3>

--- a/client/src/components/services/ServiceCard.tsx
+++ b/client/src/components/services/ServiceCard.tsx
@@ -19,7 +19,7 @@ export default function ServiceCard({ service, onClick }: ServiceCardProps) {
       className="group bg-white rounded-2xl p-8 shadow-lg border border-gray-100 hover:shadow-2xl hover:border-orange-200 transition-all duration-300 hover-scale cursor-pointer"
       onClick={onClick}
     >
-      <div className="w-16 h-16 bg-white border border-gray-200 rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
+      <div className="w-16 h-16 aspect-square bg-white border border-gray-200 rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
         {(service.category === 'plomberie' || service.name === 'Plomberie' || service.category === 'electricite' || service.name === 'Électricité') && (
           <ServiceIcon serviceName={service.category || service.name} className="w-12 h-12" />
         )}
@@ -35,7 +35,7 @@ export default function ServiceCard({ service, onClick }: ServiceCardProps) {
       
       <div className="text-orange-500 font-semibold hover:text-orange-600 transition-colors flex items-center space-x-2 rtl:space-x-reverse">
         <span>{t("services.explore")}</span>
-        <ArrowRight className="w-4 h-4 group-hover:translate-x-1 rtl:group-hover:-translate-x-1 transition-transform" />
+        <ArrowRight className="w-4 h-4 group-hover:translate-x-1 rtl:group-hover:-translate-x-1 rtl:rotate-180 transition-transform" />
       </div>
     </div>
   );

--- a/client/src/components/ui/ScrollToTop.tsx
+++ b/client/src/components/ui/ScrollToTop.tsx
@@ -9,7 +9,7 @@ export default function ScrollToTop() {
   // Détecter quand l'utilisateur a scrollé suffisamment
   useEffect(() => {
     const toggleVisibility = () => {
-      if (window.pageYOffset > 300) {
+      if (window.pageYOffset > 600) {
         setIsVisible(true);
       } else {
         setIsVisible(false);
@@ -36,15 +36,13 @@ export default function ScrollToTop() {
 
   return (
     <>
-      {isVisible && (
-        <button
-          onClick={scrollToTop}
-          className="fixed bottom-6 right-6 z-50 bg-gradient-to-r from-orange-500 to-orange-600 text-white p-3 rounded-full shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-110 animate-fade-in"
-          aria-label="Remonter en haut de la page"
-        >
-          <ChevronUp className="w-6 h-6" />
-        </button>
-      )}
+      <button
+        onClick={scrollToTop}
+        className={`fixed bottom-4 right-4 z-50 hidden md:flex bg-gradient-to-r from-orange-500 to-orange-600 text-white p-3 rounded-full shadow-lg transition-opacity duration-300 ${isVisible ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+        aria-label="Remonter en haut de la page"
+      >
+        <ChevronUp className="w-6 h-6" />
+      </button>
     </>
   );
 }

--- a/client/src/components/ui/carousel.tsx
+++ b/client/src/components/ui/carousel.tsx
@@ -214,7 +214,7 @@ const CarouselPrevious = React.forwardRef<
       onClick={scrollPrev}
       {...props}
     >
-      <ArrowLeft className="h-4 w-4" />
+      <ArrowLeft className="h-4 w-4 rtl:rotate-180" />
       <span className="sr-only">Previous slide</span>
     </Button>
   )
@@ -243,7 +243,7 @@ const CarouselNext = React.forwardRef<
       onClick={scrollNext}
       {...props}
     >
-      <ArrowRight className="h-4 w-4" />
+      <ArrowRight className="h-4 w-4 rtl:rotate-180" />
       <span className="sr-only">Next slide</span>
     </Button>
   )

--- a/client/src/contexts/LanguageContext.tsx
+++ b/client/src/contexts/LanguageContext.tsx
@@ -47,6 +47,7 @@ const translations = {
     "hero.location": "Casablanca",
     "hero.city_placeholder": "Ville (ex: Casablanca, Rabat...)",
     "hero.provider_placeholder": "Rechercher un prestataire spécifique (optionnel)",
+    "home.find_provider": "Trouver un prestataire",
     
     // Services
     "services.title": "Nos services populaires",
@@ -220,6 +221,8 @@ const translations = {
     "search.available": "Disponible",
     "search.club_pro": "Club Pro",
     "search.date": "Date",
+    "toast.search_launched": "Recherche lancée à {{city}}",
+    "toast.search_launched_generic": "Recherche lancée",
     "calendar.available": "Disponible",
     "calendar.unavailable": "Indisponible",
     "calendar.selected": "Sélectionné",
@@ -355,6 +358,7 @@ const translations = {
     // Testimonials
     "testimonials.title": "Ce que disent nos utilisateurs",
     "testimonials.subtitle": "Des milliers de clients satisfaits nous font confiance",
+    "testimonials.verified_badge": "Client vérifié",
     
     // Newsletter
     "newsletter.title": "Restez informé avec notre newsletter",
@@ -594,6 +598,7 @@ const translations = {
     "hero.location": "الدار البيضاء",
     "hero.city_placeholder": "المدينة (مثل: الدار البيضاء، الرباط...)",
     "hero.provider_placeholder": "البحث عن مقدم خدمة محدد (اختياري)",
+    "home.find_provider": "ابحث عن مقدم خدمة",
     
     // Services
     "services.title": "خدماتنا الشائعة",
@@ -624,6 +629,7 @@ const translations = {
     // Testimonials
     "testimonials.title": "ماذا يقول عملاؤنا",
     "testimonials.subtitle": "آلاف العملاء الراضين يثقون بنا",
+    "testimonials.verified_badge": "عميل موثوق",
     
     // Providers
     "providers.title": "مقدمو خدمات معتمدون",
@@ -742,6 +748,8 @@ const translations = {
     "search.available": "متاح",
     "search.club_pro": "نادي المحترفين",
     "search.date": "تاريخ",
+    "toast.search_launched": "تم بدء البحث في {{city}}",
+    "toast.search_launched_generic": "تم بدء البحث",
     "calendar.available": "متاح",
     "calendar.unavailable": "غير متاح",
     "calendar.selected": "محدد",

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -93,7 +93,12 @@
 }
 
 .pattern-bg {
-  background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23f97316' fill-opacity='0.05'%3E%3Ccircle cx='30' cy='30' r='2'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+  background-image: none;
+}
+@media (min-width: 768px) {
+  .pattern-bg {
+    background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23f97316' fill-opacity='0.05'%3E%3Ccircle cx='30' cy='30' r='2'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+  }
 }
 
 .hover-scale {

--- a/client/src/pages/Index.tsx
+++ b/client/src/pages/Index.tsx
@@ -5,15 +5,18 @@ import FeaturedProvidersCarousel from "@/components/providers/FeaturedProvidersC
 import JoinProviders from "@/components/providers/JoinProviders";
 import NewsletterSection from "@/components/ui/NewsletterSection";
 import { Button } from "@/components/ui/button";
-import { Lightbulb, Search, User, MessageCircle, Star, Wrench, Droplets, Sparkles, Palette, Hammer } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Lightbulb, Search, User, MessageCircle, Star, Wrench, Droplets, Sparkles, Palette, Hammer, Quote } from "lucide-react";
 import { Link, useLocation } from "wouter";
 import type { Service } from "@shared/schema";
 import { useGeolocation } from "@/hooks/use-geolocation";
+import { useToast } from "@/hooks/use-toast";
 
 export default function Index() {
   const { t, language } = useLanguage();
   const [, setLocation] = useLocation();
   const { city: userLocation } = useGeolocation();
+  const { toast } = useToast();
 
   // Fetch popular services
   const { data: services, isLoading: servicesLoading } = useQuery<Service[]>({
@@ -32,37 +35,42 @@ export default function Index() {
     // Rediriger vers la page Prestataires avec le service et la localisation détectée
     const params = new URLSearchParams({ service });
     if (userLocation) {
-      params.set('location', userLocation);
+      params.set("location", userLocation);
+      toast({ description: t("toast.search_launched").replace("{{city}}", userLocation) });
+    } else {
+      toast({ description: t("toast.search_launched_generic") });
     }
     setLocation(`/prestataires?${params.toString()}`);
   };
 
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen" dir={language === "ar" ? "rtl" : "ltr"}>
       {/* Hero Section */}
       <section className="relative overflow-hidden bg-gradient-to-br from-orange-50 via-white to-orange-100 pt-32 md:pt-36 pb-12 md:pb-16 pattern-bg">
         <div className="relative max-w-7xl mx-auto px-4 md:px-6 text-center">
           <div className="animate-slide-up">
-            <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-7xl font-bold text-gray-900 mb-4 md:mb-6 leading-tight px-2">
+            <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-7xl font-bold text-gray-900 mb-4 md:mb-6 leading-tight p-2">
               {t("hero.title")}
               <span className="bg-gradient-to-r from-orange-500 to-orange-600 bg-clip-text text-transparent">
                 {" "}{t("hero.title_highlight")}
               </span>
             </h1>
-            
-            <p className="text-lg md:text-xl text-gray-600 mb-6 md:mb-8 max-w-2xl mx-auto leading-relaxed px-4">
+
+            <p className="text-lg md:text-xl text-gray-600 mb-6 md:mb-8 max-w-2xl mx-auto leading-relaxed p-4">
               {t("hero.subtitle")}
             </p>
           </div>
-          
+
           {/* Smart Search Bar avec suggestions */}
-          <SmartSearch showSuggestions={true} />
-          
+          <div id="search">
+            <SmartSearch showSuggestions={true} />
+          </div>
+
         </div>
       </section>
 
       {/* Statistiques - 4 blocs d'information */}
-      <section className="py-12 bg-white">
+      <section className="py-12 md:py-16 bg-white">
         <div className="max-w-7xl mx-auto px-4 md:px-6">
           <div className="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8">
             <div className="text-center">
@@ -90,7 +98,7 @@ export default function Index() {
         {/* Background principal avec dégradé fluide - full width */}
         <div className="py-12 md:py-16 bg-gradient-to-b from-white via-gray-50 to-orange-50 w-full">
           <div className="max-w-7xl mx-auto px-4 md:px-6 relative z-10">
-            <div className="text-center mb-8 md:mb-12 px-4">
+            <div className="text-center mb-8 md:mb-12">
               <h2 className="text-2xl md:text-4xl font-bold text-gray-900 mb-4 leading-tight">
                 {t("services.popular")}
               </h2>
@@ -98,17 +106,17 @@ export default function Index() {
                 {t("services.subtitle")}
               </p>
             </div>
-            
+
             {/* Grid des services populaires */}
             {servicesLoading ? (
-              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3 md:gap-6 px-2 md:px-0">
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3 md:gap-6">
                 {Array.from({ length: 12 }).map((_, i) => (
                   <div key={i} className="rounded-2xl h-32 md:h-40 animate-pulse bg-gray-200/70" />
                 ))}
               </div>
             ) : (
-              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3 md:gap-6 px-2 md:px-0">
-                {[
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3 md:gap-6">
+                {[ 
                   { nameKey: 'services.plumbing', serviceName: 'plomberie', count: '156 prestataires', popular: true, icon: Droplets },
                   { nameKey: 'services.cleaning', serviceName: 'nettoyage', count: '89 prestataires', popular: true, icon: Sparkles },
                   { nameKey: 'services.electricity', serviceName: 'electricite', count: '134 prestataires', popular: false, icon: Lightbulb },
@@ -121,12 +129,13 @@ export default function Index() {
                   <Link
                     key={index}
                     href={`/prestataires?service=${encodeURIComponent(service.serviceName)}${userLocation ? `&location=${encodeURIComponent(userLocation)}` : ""}`}
+                    onClick={() => toast({ description: userLocation ? t("toast.search_launched").replace("{{city}}", userLocation) : t("toast.search_launched_generic") })}
                   >
                     <div className="group cursor-pointer relative">
                       <div className="bg-white border-2 border-gray-200 rounded-xl md:rounded-2xl p-3 md:p-6 text-center hover:shadow-xl hover:border-orange-300 transition-all duration-300 transform hover:-translate-y-2 shadow-md service-card-pulse">
 
-                        <div className="text-2xl md:text-4xl mb-2 md:mb-4 group-hover:scale-110 transition-transform flex items-center justify-center">
-                        <Icon aria-hidden="true" focusable="false" className="w-12 h-12 md:w-16 md:h-16 text-orange-500" />
+                        <div className="text-2xl md:text-4xl mb-2 md:mb-4 group-hover:scale-110 transition-transform flex items-center justify-center aspect-square">
+                          <Icon aria-hidden="true" focusable="false" className="w-12 h-12 md:w-16 md:h-16 text-orange-500" />
                         </div>
                         <h3 className="font-semibold md:font-bold text-sm md:text-base text-gray-900 mb-1 md:mb-2 group-hover:text-orange-600 transition-colors leading-tight">
                           {t(service.nameKey)}
@@ -166,7 +175,7 @@ export default function Index() {
           
           <div className="grid md:grid-cols-3 gap-8 md:gap-12">
             <div className="text-center">
-              <div className="w-16 h-16 md:w-20 md:h-20 bg-orange-100 rounded-full flex items-center justify-center mx-auto mb-6">
+              <div className="w-16 h-16 md:w-20 md:h-20 aspect-square bg-orange-100 rounded-full flex items-center justify-center mx-auto mb-6">
                 <Search aria-hidden="true" focusable="false" className="w-8 h-8 md:w-10 md:h-10 text-orange-600" />
               </div>
               <h3 className="text-xl md:text-2xl font-bold text-gray-900 mb-4">
@@ -176,9 +185,9 @@ export default function Index() {
                 {t("how_it_works.step1_desc")}
               </p>
             </div>
-            
+
             <div className="text-center">
-              <div className="w-16 h-16 md:w-20 md:h-20 bg-orange-100 rounded-full flex items-center justify-center mx-auto mb-6">
+              <div className="w-16 h-16 md:w-20 md:h-20 aspect-square bg-orange-100 rounded-full flex items-center justify-center mx-auto mb-6">
                 <User aria-hidden="true" focusable="false" className="w-8 h-8 md:w-10 md:h-10 text-orange-600" />
               </div>
               <h3 className="text-xl md:text-2xl font-bold text-gray-900 mb-4">
@@ -188,9 +197,9 @@ export default function Index() {
                 {t("how_it_works.step2_desc")}
               </p>
             </div>
-            
+
             <div className="text-center">
-              <div className="w-16 h-16 md:w-20 md:h-20 bg-orange-100 rounded-full flex items-center justify-center mx-auto mb-6">
+              <div className="w-16 h-16 md:w-20 md:h-20 aspect-square bg-orange-100 rounded-full flex items-center justify-center mx-auto mb-6">
                 <MessageCircle aria-hidden="true" focusable="false" className="w-8 h-8 md:w-10 md:h-10 text-orange-600" />
               </div>
               <h3 className="text-xl md:text-2xl font-bold text-gray-900 mb-4">
@@ -223,70 +232,76 @@ export default function Index() {
           </div>
           
           <div className="grid md:grid-cols-3 gap-8">
-            <div className="bg-white rounded-2xl p-6 md:p-8 shadow-lg">
+            <div className="bg-white rounded-2xl p-6 md:p-8 shadow-lg" aria-label="Témoignage">
               <div className="flex items-center mb-4">
-                <div className="flex space-x-1" aria-label="Note 5 sur 5">
+                <div className="w-10 h-10 rounded-full overflow-hidden aspect-square mr-3">
+                  <img src="https://via.placeholder.com/40" alt="" loading="lazy" decoding="async" className="w-full h-full object-cover" />
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="font-semibold text-gray-900">{t("testimonials.user1")}</span>
+                  <Badge variant="secondary" className="text-xs">{t("testimonials.verified_badge")}</Badge>
+                </div>
+              </div>
+              <div className="flex items-center mb-4">
+                <div className="flex space-x-1 rtl:space-x-reverse" aria-label="Note 5 sur 5">
                   {Array.from({ length: 5 }).map((_, i) => (
                     <Star key={i} aria-hidden="true" className="w-5 h-5 text-yellow-400 fill-current" />
                   ))}
                 </div>
               </div>
-              <p className="text-gray-700 mb-4 leading-relaxed">
-                "{t("testimonials.review1")}"
+              <p className="text-gray-700 mb-4 leading-relaxed font-medium relative">
+                <Quote className="w-5 h-5 text-orange-500 absolute -top-2 -left-2 rtl:-right-2 rtl:left-auto rtl:rotate-180" />
+                {t("testimonials.review1")}
               </p>
-              <div className="flex items-center">
-                <div className="w-10 h-10 bg-orange-100 rounded-full flex items-center justify-center mr-3">
-                  <User aria-hidden="true" focusable="false" className="w-5 h-5 text-orange-600" />
-                </div>
-                <div>
-                  <div className="font-semibold text-gray-900">{t("testimonials.user1")}</div>
-                  <div className="text-sm text-gray-600">{t("testimonials.city1")}</div>
-                </div>
-              </div>
+              <div className="text-sm text-gray-600">{t("testimonials.city1")}</div>
             </div>
-            
-            <div className="bg-white rounded-2xl p-6 md:p-8 shadow-lg">
+
+            <div className="bg-white rounded-2xl p-6 md:p-8 shadow-lg" aria-label="Témoignage">
               <div className="flex items-center mb-4">
-                <div className="flex space-x-1" aria-label="Note 5 sur 5">
+                <div className="w-10 h-10 rounded-full overflow-hidden aspect-square mr-3">
+                  <img src="https://via.placeholder.com/40" alt="" loading="lazy" decoding="async" className="w-full h-full object-cover" />
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="font-semibold text-gray-900">{t("testimonials.user2")}</span>
+                  <Badge variant="secondary" className="text-xs">{t("testimonials.verified_badge")}</Badge>
+                </div>
+              </div>
+              <div className="flex items-center mb-4">
+                <div className="flex space-x-1 rtl:space-x-reverse" aria-label="Note 5 sur 5">
                   {Array.from({ length: 5 }).map((_, i) => (
                     <Star key={i} aria-hidden="true" className="w-5 h-5 text-yellow-400 fill-current" />
                   ))}
                 </div>
               </div>
-              <p className="text-gray-700 mb-4 leading-relaxed">
-                "{t("testimonials.review2")}"
+              <p className="text-gray-700 mb-4 leading-relaxed font-medium relative">
+                <Quote className="w-5 h-5 text-orange-500 absolute -top-2 -left-2 rtl:-right-2 rtl:left-auto rtl:rotate-180" />
+                {t("testimonials.review2")}
               </p>
-              <div className="flex items-center">
-                <div className="w-10 h-10 bg-orange-100 rounded-full flex items-center justify-center mr-3">
-                  <User aria-hidden="true" focusable="false" className="w-5 h-5 text-orange-600" />
-                </div>
-                <div>
-                  <div className="font-semibold text-gray-900">{t("testimonials.user2")}</div>
-                  <div className="text-sm text-gray-600">{t("testimonials.city2")}</div>
-                </div>
-              </div>
+              <div className="text-sm text-gray-600">{t("testimonials.city2")}</div>
             </div>
-            
-            <div className="bg-white rounded-2xl p-6 md:p-8 shadow-lg">
+
+            <div className="bg-white rounded-2xl p-6 md:p-8 shadow-lg" aria-label="Témoignage">
               <div className="flex items-center mb-4">
-                <div className="flex space-x-1" aria-label="Note 5 sur 5">
+                <div className="w-10 h-10 rounded-full overflow-hidden aspect-square mr-3">
+                  <img src="https://via.placeholder.com/40" alt="" loading="lazy" decoding="async" className="w-full h-full object-cover" />
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="font-semibold text-gray-900">{t("testimonials.user3")}</span>
+                  <Badge variant="secondary" className="text-xs">{t("testimonials.verified_badge")}</Badge>
+                </div>
+              </div>
+              <div className="flex items-center mb-4">
+                <div className="flex space-x-1 rtl:space-x-reverse" aria-label="Note 5 sur 5">
                   {Array.from({ length: 5 }).map((_, i) => (
                     <Star key={i} aria-hidden="true" className="w-5 h-5 text-yellow-400 fill-current" />
                   ))}
                 </div>
               </div>
-              <p className="text-gray-700 mb-4 leading-relaxed">
-                "{t("testimonials.review3")}"
+              <p className="text-gray-700 mb-4 leading-relaxed font-medium relative">
+                <Quote className="w-5 h-5 text-orange-500 absolute -top-2 -left-2 rtl:-right-2 rtl:left-auto rtl:rotate-180" />
+                {t("testimonials.review3")}
               </p>
-              <div className="flex items-center">
-                <div className="w-10 h-10 bg-orange-100 rounded-full flex items-center justify-center mr-3">
-                  <User aria-hidden="true" focusable="false" className="w-5 h-5 text-orange-600" />
-                </div>
-                <div>
-                  <div className="font-semibold text-gray-900">{t("testimonials.user3")}</div>
-                  <div className="text-sm text-gray-600">{t("testimonials.city3")}</div>
-                </div>
-              </div>
+              <div className="text-sm text-gray-600">{t("testimonials.city3")}</div>
             </div>
           </div>
         </div>
@@ -294,6 +309,11 @@ export default function Index() {
 
       {/* Newsletter - Repositionnée après les témoignages */}
       <NewsletterSection />
+
+      {/* Bottom CTA mobile */}
+      <a href="#search" className="md:hidden fixed bottom-4 inset-x-4 z-50">
+        <Button className="w-full">{t("home.find_provider")}</Button>
+      </a>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add rtl-aware layout with bottom CTA and testimonial headers
- rotate directional icons in rtl and lazy-load card images
- apply desktop-only background pattern and scroll-to-top FAB

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Type 'string[] | null | undefined' is not assignable to type 'string[] | null')*

------
https://chatgpt.com/codex/tasks/task_e_6897683798c48328992ad21ac76296cc