### PR TITLE
Add backend authentication and request utilities

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,9 +14,13 @@
     "cors": "^2.8.5",
     "express": "^4.21.2",
     "helmet": "^8.1.0",
-    "@prisma/client": "^5.16.1"
+    "@prisma/client": "^5.16.1",
+    "express-rate-limit": "^8.0.1",
+    "jsonwebtoken": "^9.0.2",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
-    "prisma": "^5.16.1"
+    "prisma": "^5.16.1",
+    "@types/jsonwebtoken": "^9.0.10"
   }
 }

--- a/backend/src/middlewares/auth.ts
+++ b/backend/src/middlewares/auth.ts
@@ -1,0 +1,74 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+export type UserRole = 'client' | 'provider' | 'admin';
+
+interface JwtPayload {
+  id: string;
+  role: UserRole;
+}
+
+export function authenticate(req: Request, res: Response, next: NextFunction) {
+  const authHeader = req.headers['authorization'];
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({
+      success: false,
+      error: {
+        code: 401,
+        message: 'Authorization header missing or malformed',
+        timestamp: new Date().toISOString(),
+      },
+    });
+  }
+
+  const token = authHeader.split(' ')[1];
+
+  try {
+    const secret = process.env.JWT_SECRET;
+    if (!secret) throw new Error('JWT secret not configured');
+
+    const decoded = jwt.verify(token, secret) as JwtPayload;
+    req.user = { id: decoded.id, role: decoded.role };
+    next();
+  } catch {
+    return res.status(401).json({
+      success: false,
+      error: {
+        code: 401,
+        message: 'Invalid or expired token',
+        timestamp: new Date().toISOString(),
+      },
+    });
+  }
+}
+
+export function requireRole(...roles: UserRole[]) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const userRole = req.user?.role;
+    if (!userRole || !roles.includes(userRole)) {
+      return res.status(403).json({
+        success: false,
+        error: {
+          code: 403,
+          message: 'Forbidden',
+          timestamp: new Date().toISOString(),
+        },
+      });
+    }
+    next();
+  };
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: {
+        id: string;
+        role: UserRole;
+      };
+    }
+  }
+}
+
+export {};

--- a/backend/src/middlewares/rateLimit.ts
+++ b/backend/src/middlewares/rateLimit.ts
@@ -1,0 +1,21 @@
+import rateLimit from 'express-rate-limit';
+
+function createLimiter(max: number, message: string) {
+  return rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      success: false,
+      error: {
+        code: 429,
+        message,
+        timestamp: new Date().toISOString(),
+      },
+    },
+  });
+}
+
+export const loginLimiter = createLimiter(5, 'Too many login attempts, please try again later.');
+export const paymentsLimiter = createLimiter(100, 'Too many requests, please try again later.');

--- a/backend/src/middlewares/validation.ts
+++ b/backend/src/middlewares/validation.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction } from 'express';
+import { AnyZodObject, ZodError } from 'zod';
+
+export function validate(schema: AnyZodObject) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      schema.parse({
+        body: req.body,
+        params: req.params,
+        query: req.query,
+      });
+      next();
+    } catch (err) {
+      const details = err instanceof ZodError ? err.errors : [];
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 400,
+          message: 'Validation error',
+          details,
+          timestamp: new Date().toISOString(),
+        },
+      });
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add JWT-based auth middleware with role checks
- add zod-powered request validation helper
- add rate limiters for login and payment routes
- include required backend dependencies

## Testing
- `npm --prefix backend run build`

------
https://chatgpt.com/codex/tasks/task_e_68977d770ed0832886156091eab8247a