### PR TITLE
feat: add auth routes and controller

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,8 @@
     "@prisma/client": "^5.16.1",
     "express-rate-limit": "^8.0.1",
     "jsonwebtoken": "^9.0.2",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "bcrypt": "^5.1.1"
   },
   "devDependencies": {
     "prisma": "^5.16.1",

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,0 +1,101 @@
+import { Request, Response, NextFunction } from 'express';
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import type { UserRole } from '../middlewares/auth';
+
+type Role = 'CLIENT' | 'PROVIDER' | 'ADMIN';
+
+const prisma = new PrismaClient();
+
+export async function register(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { email, password, role } = req.body as {
+      email: string;
+      password: string;
+      role?: Role;
+    };
+
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      return next({ status: 400, message: 'Email already registered' });
+    }
+
+    const hashed = await bcrypt.hash(password, 12);
+    const newUser = await prisma.user.create({
+      data: {
+        email,
+        password: hashed,
+        role: role ?? 'CLIENT',
+        isVerified: true,
+      },
+      select: { id: true, email: true, role: true },
+    });
+
+    res.status(201).json({
+      success: true,
+      data: { user: newUser },
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function login(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { email, password } = req.body as { email: string; password: string };
+
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) {
+      return next({ status: 401, message: 'Invalid credentials' });
+    }
+
+    const valid = await bcrypt.compare(password, user.password);
+    if (!valid) {
+      return next({ status: 401, message: 'Invalid credentials' });
+    }
+
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      return next({ status: 500, message: 'JWT secret not configured' });
+    }
+
+    const accessToken = jwt.sign(
+      { id: user.id.toString(), role: user.role.toLowerCase() as UserRole },
+      secret,
+      { expiresIn: '15m' }
+    );
+
+    res.json({
+      success: true,
+      data: {
+        accessToken,
+        user: { id: user.id, email: user.email, role: user.role },
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function profile(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseInt(req.user?.id || '', 10);
+    if (!id) {
+      return next({ status: 401, message: 'Unauthorized' });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id },
+      select: { id: true, email: true, role: true },
+    });
+
+    if (!user) {
+      return next({ status: 404, message: 'User not found' });
+    }
+
+    res.json({ success: true, data: { user } });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { register, login, profile } from '../controllers/authController';
+import { validate } from '../middlewares/validation';
+import { authenticate } from '../middlewares/auth';
+import { loginLimiter } from '../middlewares/rateLimit';
+
+const router = Router();
+
+const registerSchema = z.object({
+  body: z.object({
+    email: z.string().email(),
+    password: z.string().min(8),
+    role: z.enum(['CLIENT', 'PROVIDER', 'ADMIN']).optional(),
+  }),
+});
+
+const loginSchema = z.object({
+  body: z.object({
+    email: z.string().email(),
+    password: z.string().min(8),
+  }),
+});
+
+router.post('/register', validate(registerSchema), register);
+router.post('/login', loginLimiter, validate(loginSchema), login);
+router.get('/profile', authenticate, profile);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,6 +3,7 @@ import helmet from 'helmet';
 import cors from 'cors';
 import { env } from './config/env';
 import { errorHandler } from './middlewares/errorHandler';
+import authRoutes from './routes/auth';
 
 const app = express();
 
@@ -13,6 +14,8 @@ app.use(cors({ origin: env.frontendUrl }));
 app.get('/health', (_req, res) => {
   res.json({ success: true });
 });
+
+app.use('/api/auth', authRoutes);
 
 app.use(errorHandler);
 


### PR DESCRIPTION
## Summary
- add authentication controller for register, login, and profile endpoints
- create auth routes with validation, JWT, and rate limiting
- mount auth routes on `/api/auth` and add bcrypt dependency

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Cannot find module 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_68977f12db60832897e782220a1c97e7