### PR TITLE
feat: add subscription endpoints

### DIFF
--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -1,0 +1,62 @@
+import { Request, Response, NextFunction } from 'express';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function createClubProSubscription(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = parseInt(req.user?.id || '', 10);
+    if (!userId) {
+      return next({ status: 401, message: 'Unauthorized' });
+    }
+
+    const active = await prisma.subscription.findFirst({
+      where: { userId, type: 'CLUB_PRO', status: 'ACTIVE' },
+    });
+
+    if (active) {
+      return next({ status: 409, message: 'Active subscription already exists' });
+    }
+
+    let subscription = await prisma.subscription.findFirst({
+      where: { userId, type: 'CLUB_PRO', status: 'PENDING' },
+    });
+
+    let status = 200;
+    if (!subscription) {
+      subscription = await prisma.subscription.create({
+        data: {
+          userId,
+          type: 'CLUB_PRO',
+          status: 'PENDING',
+          price: 50,
+          autoRenew: true,
+        },
+      });
+      status = 201;
+    }
+
+    res.status(status).json({ success: true, data: { subscription } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function listMySubscriptions(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = parseInt(req.user?.id || '', 10);
+    if (!userId) {
+      return next({ status: 401, message: 'Unauthorized' });
+    }
+
+    const subscriptions = await prisma.subscription.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    res.json({ success: true, data: { subscriptions } });
+  } catch (err) {
+    next(err);
+  }
+}
+

--- a/backend/src/routes/subscriptions.ts
+++ b/backend/src/routes/subscriptions.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { authenticate, requireRole } from '../middlewares/auth';
+import { createClubProSubscription, listMySubscriptions } from '../controllers/subscriptionController';
+
+const router = Router();
+
+router.post('/club-pro', authenticate, requireRole('provider'), createClubProSubscription);
+router.get('/', authenticate, listMySubscriptions);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,6 +4,7 @@ import cors from 'cors';
 import { env } from './config/env';
 import { errorHandler } from './middlewares/errorHandler';
 import authRoutes from './routes/auth';
+import subscriptionRoutes from './routes/subscriptions';
 
 const app = express();
 
@@ -16,6 +17,7 @@ app.get('/health', (_req, res) => {
 });
 
 app.use('/api/auth', authRoutes);
+app.use('/api/subscriptions', subscriptionRoutes);
 
 app.use(errorHandler);
 


### PR DESCRIPTION
## Summary
- implement controller for creating and listing user subscriptions
- add routes and mount under `/api/subscriptions`

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689788c964a0832883cad63109e1adc2