### PR TITLE
feat: add stripe payments integration

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,13 +13,14 @@
   },
   "dependencies": {
     "@prisma/client": "^5.16.1",
+    "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "express": "^4.21.2",
     "express-rate-limit": "^8.0.1",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
-    "zod": "^3.24.2",
-    "bcryptjs": "^3.0.2"
+    "stripe": "^16.7.0",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.10",

--- a/backend/prisma/migrations/20250809175711_add_subscription_user_status_index/migration.sql
+++ b/backend/prisma/migrations/20250809175711_add_subscription_user_status_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Subscription_userId_status_idx" ON "Subscription"("userId", "status");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -33,4 +33,6 @@ model Subscription {
   stripeId  String?
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
+
+  @@index([userId, status])
 }

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -4,5 +4,8 @@ export const env = {
   databaseUrl: process.env.DATABASE_URL || '',
   jwtSecret: process.env.JWT_SECRET || '',
   stripePublicKey: process.env.STRIPE_PUBLIC_KEY || '',
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY || ''
+  stripeSecretKey: process.env.STRIPE_SECRET_KEY || '',
+  stripeWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET || '',
+  stripePriceId: process.env.STRIPE_PRICE_ID,
+  currency: process.env.CURRENCY || 'mad'
 };

--- a/backend/src/config/stripe.ts
+++ b/backend/src/config/stripe.ts
@@ -1,0 +1,5 @@
+import Stripe from 'stripe';
+
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2024-06-20'
+});

--- a/backend/src/controllers/paymentController.ts
+++ b/backend/src/controllers/paymentController.ts
@@ -1,0 +1,96 @@
+import { Request, Response, NextFunction } from 'express';
+import Stripe from 'stripe';
+import { PrismaClient } from '@prisma/client';
+import { stripe } from '../config/stripe';
+import { env } from '../config/env';
+import { addMonths } from '../utils/date';
+
+const prisma = new PrismaClient();
+
+export async function createClubProCheckout(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = parseInt(req.user?.id || '', 10);
+    if (!userId) {
+      return next({ status: 401, message: 'Unauthorized' });
+    }
+
+    const subscription = await prisma.subscription.findFirst({
+      where: { userId, type: 'CLUB_PRO', status: 'PENDING' }
+    });
+
+    if (!subscription) {
+      return next({ status: 400, message: 'Create subscription via /api/subscriptions/club-pro' });
+    }
+
+    let session: Stripe.Checkout.Session;
+    if (process.env.STRIPE_PRICE_ID) {
+      session = await stripe.checkout.sessions.create({
+        mode: 'subscription',
+        line_items: [{ price: process.env.STRIPE_PRICE_ID!, quantity: 1 }],
+        metadata: {
+          userId: String(userId),
+          subscriptionId: String(subscription.id)
+        },
+        success_url: `${env.frontendUrl}/club-pro?status=success`,
+        cancel_url: `${env.frontendUrl}/club-pro?status=cancel`
+      });
+    } else {
+      session = await stripe.checkout.sessions.create({
+        mode: 'payment',
+        line_items: [{
+          price_data: {
+            currency: process.env.CURRENCY ?? 'mad',
+            product_data: { name: 'Abonnement Club Pro (12 mois)' },
+            unit_amount: 5000
+          },
+          quantity: 1
+        }],
+        metadata: {
+          userId: String(userId),
+          subscriptionId: String(subscription.id)
+        },
+        success_url: `${env.frontendUrl}/club-pro?status=success`,
+        cancel_url: `${env.frontendUrl}/club-pro?status=cancel`
+      });
+    }
+
+    res.json({ success: true, data: { url: session.url } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function handleStripeWebhook(req: Request, res: Response, _next: NextFunction) {
+  const sig = req.headers['stripe-signature'];
+  let event: Stripe.Event;
+
+  try {
+    event = stripe.webhooks.constructEvent(req.body, sig as string, process.env.STRIPE_WEBHOOK_SECRET!);
+  } catch (err: any) {
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as Stripe.Checkout.Session;
+    const subscriptionId = session.metadata?.subscriptionId;
+    if (subscriptionId) {
+      const id = parseInt(subscriptionId, 10);
+      const subscription = await prisma.subscription.findUnique({ where: { id } });
+      if (subscription && subscription.status !== 'ACTIVE') {
+        const startDate = new Date();
+        const endDate = addMonths(startDate, 12);
+        await prisma.subscription.update({
+          where: { id },
+          data: {
+            status: 'ACTIVE',
+            startDate,
+            endDate,
+            stripeId: session.id
+          }
+        });
+      }
+    }
+  }
+
+  res.sendStatus(200);
+}

--- a/backend/src/routes/payments.ts
+++ b/backend/src/routes/payments.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { authenticate, requireRole } from '../middlewares/auth';
+import { paymentsLimiter } from '../middlewares/rateLimit';
+import { createClubProCheckout } from '../controllers/paymentController';
+
+const router = Router();
+
+router.post('/club-pro', authenticate, requireRole('provider'), paymentsLimiter, createClubProCheckout);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5,8 +5,12 @@ import { env } from './config/env';
 import { errorHandler } from './middlewares/errorHandler';
 import authRoutes from './routes/auth';
 import subscriptionRoutes from './routes/subscriptions';
+import paymentRoutes from './routes/payments';
+import { handleStripeWebhook } from './controllers/paymentController';
 
 const app = express();
+
+app.post('/api/payments/webhook', express.raw({ type: 'application/json' }), handleStripeWebhook);
 
 app.use(express.json());
 app.use(helmet());
@@ -18,6 +22,7 @@ app.get('/health', (_req, res) => {
 
 app.use('/api/auth', authRoutes);
 app.use('/api/subscriptions', subscriptionRoutes);
+app.use('/api/payments', paymentRoutes);
 
 app.use(errorHandler);
 

--- a/backend/src/utils/date.ts
+++ b/backend/src/utils/date.ts
@@ -1,0 +1,9 @@
+export function addMonths(date: Date, months: number): Date {
+  const d = new Date(date);
+  const day = d.getDate();
+  d.setMonth(d.getMonth() + months);
+  if (d.getDate() < day) {
+    d.setDate(0);
+  }
+  return d;
+}


### PR DESCRIPTION
## Summary
- add stripe client configuration
- enable Club Pro checkout and webhook handling
- index subscriptions by user and status

## Testing
- `DATABASE_URL="file:./dev.db" npx prisma migrate dev --name add_subscription_user_status_index`
- `npm test`
- `npm test || true`

------
https://chatgpt.com/codex/tasks/task_e_68978aaa1c88832882d7274dd649b697