### PR TITLE
feat: make checkout currency and amount configurable

### DIFF
--- a/backend/src/controllers/paymentController.ts
+++ b/backend/src/controllers/paymentController.ts
@@ -35,13 +35,16 @@ export async function createClubProCheckout(req: Request, res: Response, next: N
         cancel_url: `${env.frontendUrl}/club-pro?status=cancel`
       });
     } else {
+      const currency = process.env.CURRENCY ?? 'mad';
+      const amount = Number(process.env.CLUB_PRO_AMOUNT ?? 5000);
+
       session = await stripe.checkout.sessions.create({
         mode: 'payment',
         line_items: [{
           price_data: {
-            currency: process.env.CURRENCY ?? 'mad',
+            currency,
             product_data: { name: 'Abonnement Club Pro (12 mois)' },
-            unit_amount: 5000
+            unit_amount: amount
           },
           quantity: 1
         }],


### PR DESCRIPTION
## Summary
- allow configuring checkout currency and amount via environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68979d3e03b08328b743e8430e4b9a4f