### PR TITLE
feat: add cURL helpers for Club Pro E2E

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "start": "node dist/server.js",
     "db:migrate": "echo \"db migrate not implemented\"",
     "db:seed": "echo \"db seed not implemented\"",
-    "test": "echo \"No tests yet\" && exit 0"
+    "test": "echo \"No tests yet\" && exit 0",
+    "e2e:clubpro:curl": "node scripts/print-e2e-curls.js"
   },
   "dependencies": {
     "@prisma/client": "^5.16.1",

--- a/backend/scripts/print-e2e-curls.js
+++ b/backend/scripts/print-e2e-curls.js
@@ -1,0 +1,25 @@
+const base = 'http://localhost:3000';
+const email = 'provider@example.com';
+const password = 'Password123';
+
+console.log('# Register provider');
+console.log(`curl -X POST ${base}/api/auth/register \\
+  -H 'Content-Type: application/json' \\
+  -d '{"email":"${email}","password":"${password}","role":"PROVIDER"}'\n`);
+
+console.log('# Login and capture token');
+console.log(`TOKEN=$(curl -s -X POST ${base}/api/auth/login \\
+  -H 'Content-Type: application/json' \\
+  -d '{"email":"${email}","password":"${password}"}' | jq -r '.data.accessToken')\n`);
+
+console.log('# Create pending subscription');
+console.log(`curl -X POST ${base}/api/subscriptions/club-pro \\
+  -H "Authorization: Bearer $TOKEN"\n`);
+
+console.log('# Create checkout session');
+console.log(`curl -X POST ${base}/api/payments/club-pro \\
+  -H "Authorization: Bearer $TOKEN"\n`);
+
+console.log('# Stripe webhook listener');
+console.log('stripe listen --forward-to http://localhost:3000/api/payments/webhook');
+

--- a/docs/e2e-clubpro.md
+++ b/docs/e2e-clubpro.md
@@ -1,0 +1,19 @@
+# E2E Club Pro
+
+1. Démarrer le serveur backend :
+   ```bash
+   npm --prefix backend run dev
+   ```
+2. Dans un autre terminal, écouter les webhooks Stripe :
+   ```bash
+   stripe listen --forward-to http://localhost:3000/api/payments/webhook
+   ```
+3. Générer les commandes cURL :
+   ```bash
+   npm --prefix backend run e2e:clubpro:curl
+   ```
+4. Exécuter les cURL affichés dans l'ordre pour :
+   - enregistrer un fournisseur,
+   - se connecter et récupérer le token,
+   - créer un abonnement Club Pro en attente,
+   - créer une session de paiement.


### PR DESCRIPTION
## Summary
- add npm script to print cURLs for Club Pro flow
- document Club Pro E2E steps

## Testing
- `npm test`
- `npm run e2e:clubpro:curl`


------
https://chatgpt.com/codex/tasks/task_e_6897a7d8e0248328bd177906ca2550a7