### PR TITLE
Add booking system with day-based scheduling and messaging

### DIFF
--- a/backend/prisma/migrations/20250809203644_bookings_day_chat/migration.sql
+++ b/backend/prisma/migrations/20250809203644_bookings_day_chat/migration.sql
@@ -1,0 +1,49 @@
+-- CreateTable
+CREATE TABLE "Booking" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "clientId" INTEGER NOT NULL,
+    "providerId" INTEGER NOT NULL,
+    "serviceId" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "scheduledDay" TEXT NOT NULL,
+    "proposedDay" TEXT,
+    "agreedStartTime" TEXT,
+    "price" INTEGER NOT NULL DEFAULT 0,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Booking_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Booking_providerId_fkey" FOREIGN KEY ("providerId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Booking_serviceId_fkey" FOREIGN KEY ("serviceId") REFERENCES "Service" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "bookingId" INTEGER,
+    "senderId" INTEGER NOT NULL,
+    "receiverId" INTEGER NOT NULL,
+    "content" TEXT NOT NULL,
+    "isSystem" BOOLEAN NOT NULL DEFAULT false,
+    "isRead" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Message_bookingId_fkey" FOREIGN KEY ("bookingId") REFERENCES "Booking" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Message_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Message_receiverId_fkey" FOREIGN KEY ("receiverId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "idx_booking_client_status" ON "Booking"("clientId", "status");
+
+-- CreateIndex
+CREATE INDEX "idx_booking_provider_status" ON "Booking"("providerId", "status");
+
+-- CreateIndex
+CREATE INDEX "idx_booking_scheduledDay" ON "Booking"("scheduledDay");
+
+-- CreateIndex
+CREATE INDEX "Message_bookingId_idx" ON "Message"("bookingId");
+
+-- CreateIndex
+CREATE INDEX "Message_senderId_receiverId_createdAt_idx" ON "Message"("senderId", "receiverId", "createdAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,10 @@ model User {
   updatedAt     DateTime       @updatedAt
   subscriptions Subscription[]
   provider      Provider?
+  clientBookings   Booking[] @relation("clientBookings")
+  providerBookings Booking[] @relation("providerBookings")
+  sentMessages     Message[] @relation("MessageSender")
+  receivedMessages Message[] @relation("MessageReceiver")
 }
 
 model Subscription {
@@ -72,6 +76,51 @@ model Service {
   isPopular     Boolean  @default(false)
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
+  bookings      Booking[]
 
   @@index([providerId, category], map: "idx_service_provider_category")
+}
+
+model Booking {
+  id              Int            @id @default(autoincrement())
+  clientId        Int
+  providerId      Int
+  serviceId       Int
+  title           String
+  description     String
+  scheduledDay    String
+  proposedDay     String?
+  agreedStartTime String?
+  price           Int            @default(0)
+  status          String         @default("PENDING")
+  createdAt       DateTime       @default(now())
+  updatedAt       DateTime       @updatedAt
+
+  client   User    @relation("clientBookings", fields: [clientId], references: [id])
+  provider User    @relation("providerBookings", fields: [providerId], references: [id])
+  service  Service @relation(fields: [serviceId], references: [id])
+
+  messages Message[]
+
+  @@index([clientId, status], map: "idx_booking_client_status")
+  @@index([providerId, status], map: "idx_booking_provider_status")
+  @@index([scheduledDay], map: "idx_booking_scheduledDay")
+}
+
+model Message {
+  id         Int       @id @default(autoincrement())
+  bookingId  Int?
+  senderId   Int
+  receiverId Int
+  content    String
+  isSystem   Boolean   @default(false)
+  isRead     Boolean   @default(false)
+  createdAt  DateTime  @default(now())
+
+  booking    Booking?  @relation(fields: [bookingId], references: [id])
+  sender     User      @relation("MessageSender", fields: [senderId], references: [id])
+  receiver   User      @relation("MessageReceiver", fields: [receiverId], references: [id])
+
+  @@index([bookingId])
+  @@index([senderId, receiverId, createdAt])
 }

--- a/backend/src/controllers/bookingController.ts
+++ b/backend/src/controllers/bookingController.ts
@@ -1,0 +1,280 @@
+import { Request, Response, NextFunction } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { isValidDay, isFutureOrTodayDay } from '../utils/day';
+import { notifyUser } from '../utils/notify';
+import { createSystemMessage } from '../utils/messages';
+
+const prisma = new PrismaClient();
+
+const STATUS = {
+  PENDING: 'PENDING',
+  CONFIRMED: 'CONFIRMED',
+  RESCHEDULE_PROPOSED: 'RESCHEDULE_PROPOSED',
+  CANCELLED: 'CANCELLED',
+  REJECTED: 'REJECTED',
+  COMPLETED: 'COMPLETED',
+} as const;
+
+export async function createBooking(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = parseInt(req.user?.id || '', 10);
+    if (!userId) return next({ status: 401, message: 'Unauthorized' });
+
+    const { serviceId, title, description, scheduledDay, price } = req.body;
+
+    if (!isValidDay(scheduledDay) || !isFutureOrTodayDay(scheduledDay)) {
+      return next({ status: 400, message: 'Invalid scheduledDay' });
+    }
+
+    const service = await prisma.service.findUnique({
+      where: { id: serviceId },
+      include: { provider: true },
+    });
+    if (!service) return next({ status: 404, message: 'Service not found' });
+
+    const providerId = service.provider.userId;
+
+    const booking = await prisma.booking.create({
+      data: {
+        clientId: userId,
+        providerId,
+        serviceId,
+        title,
+        description,
+        scheduledDay,
+        price: price ?? service.basePrice,
+      },
+    });
+
+    await createSystemMessage({
+      bookingId: booking.id,
+      senderId: userId,
+      receiverId: providerId,
+      content: 'Réservation créée — en attente de votre confirmation.',
+    });
+
+    await notifyUser(providerId, 'booking_created', 'Nouvelle réservation', 'Réservation créée — en attente de votre confirmation.', { bookingId: booking.id });
+
+    res.status(201).json({ success: true, data: { booking } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function confirmBooking(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const userId = parseInt(req.user?.id || '', 10);
+    const booking = await prisma.booking.findUnique({ where: { id } });
+    if (!booking) return next({ status: 404, message: 'Booking not found' });
+    if (booking.providerId !== userId) return next({ status: 403, message: 'Forbidden' });
+    if (booking.status !== STATUS.PENDING) return next({ status: 409, message: 'Invalid status' });
+
+    const updated = await prisma.booking.update({
+      where: { id },
+      data: { status: STATUS.CONFIRMED, proposedDay: null },
+    });
+
+    await createSystemMessage({
+      bookingId: updated.id,
+      senderId: userId,
+      receiverId: updated.clientId,
+      content: 'Réservation acceptée. Fixez l\u2019horaire dans ce chat.',
+    });
+
+    await notifyUser(updated.clientId, 'booking_confirmed', 'Réservation acceptée', 'Réservation acceptée. Fixez l\u2019horaire dans ce chat.', { bookingId: updated.id });
+
+    res.json({ success: true, data: { booking: updated } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function proposeDay(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const { proposedDay } = req.body;
+    const userId = parseInt(req.user?.id || '', 10);
+
+    if (!isValidDay(proposedDay) || !isFutureOrTodayDay(proposedDay)) {
+      return next({ status: 400, message: 'Invalid proposedDay' });
+    }
+
+    const booking = await prisma.booking.findUnique({ where: { id } });
+    if (!booking) return next({ status: 404, message: 'Booking not found' });
+    if (booking.providerId !== userId) return next({ status: 403, message: 'Forbidden' });
+    if (booking.status !== STATUS.PENDING && booking.status !== STATUS.CONFIRMED) {
+      return next({ status: 409, message: 'Invalid status' });
+    }
+
+    const updated = await prisma.booking.update({
+      where: { id },
+      data: { status: STATUS.RESCHEDULE_PROPOSED, proposedDay },
+    });
+
+    await createSystemMessage({
+      bookingId: updated.id,
+      senderId: userId,
+      receiverId: updated.clientId,
+      content: `Nouveau jour propos\u00e9 : ${proposedDay}.`,
+    });
+
+    await notifyUser(updated.clientId, 'booking_reschedule_proposed', 'Proposition de nouveau jour', `Nouveau jour propos\u00e9 : ${proposedDay}.`, { bookingId: updated.id });
+
+    res.json({ success: true, data: { booking: updated } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function acceptReschedule(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const userId = parseInt(req.user?.id || '', 10);
+
+    const booking = await prisma.booking.findUnique({ where: { id } });
+    if (!booking) return next({ status: 404, message: 'Booking not found' });
+    if (booking.clientId !== userId) return next({ status: 403, message: 'Forbidden' });
+    if (booking.status !== STATUS.RESCHEDULE_PROPOSED || !booking.proposedDay) {
+      return next({ status: 409, message: 'Invalid status' });
+    }
+
+    const updated = await prisma.booking.update({
+      where: { id },
+      data: {
+        scheduledDay: booking.proposedDay,
+        proposedDay: null,
+        status: STATUS.CONFIRMED,
+      },
+    });
+
+    await createSystemMessage({
+      bookingId: updated.id,
+      senderId: userId,
+      receiverId: updated.providerId,
+      content: `Le client a accept\u00e9 le nouveau jour : ${updated.scheduledDay}.`,
+    });
+
+    await notifyUser(updated.providerId, 'booking_reschedule_accepted', 'Nouveau jour accept\u00e9', `Le client a accept\u00e9 le nouveau jour : ${updated.scheduledDay}.`, { bookingId: updated.id });
+
+    res.json({ success: true, data: { booking: updated } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function rejectBooking(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const userId = parseInt(req.user?.id || '', 10);
+    const booking = await prisma.booking.findUnique({ where: { id } });
+    if (!booking) return next({ status: 404, message: 'Booking not found' });
+    if (booking.providerId !== userId) return next({ status: 403, message: 'Forbidden' });
+    if (booking.status !== STATUS.PENDING && booking.status !== STATUS.RESCHEDULE_PROPOSED) {
+      return next({ status: 409, message: 'Invalid status' });
+    }
+
+    const updated = await prisma.booking.update({
+      where: { id },
+      data: { status: STATUS.REJECTED },
+    });
+
+    await createSystemMessage({
+      bookingId: updated.id,
+      senderId: userId,
+      receiverId: updated.clientId,
+      content: 'Le prestataire a refus\u00e9 la r\u00e9servation.',
+    });
+
+    await notifyUser(updated.clientId, 'booking_rejected', 'R\u00e9servation refus\u00e9e', 'Le prestataire a refus\u00e9 la r\u00e9servation.', { bookingId: updated.id });
+
+    res.json({ success: true, data: { booking: updated } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function cancelBooking(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const userId = parseInt(req.user?.id || '', 10);
+    const booking = await prisma.booking.findUnique({ where: { id } });
+    if (!booking) return next({ status: 404, message: 'Booking not found' });
+    if (booking.clientId !== userId) return next({ status: 403, message: 'Forbidden' });
+    if (
+      booking.status !== STATUS.PENDING &&
+      booking.status !== STATUS.CONFIRMED &&
+      booking.status !== STATUS.RESCHEDULE_PROPOSED
+    ) {
+      return next({ status: 409, message: 'Invalid status' });
+    }
+
+    const updated = await prisma.booking.update({
+      where: { id },
+      data: { status: STATUS.CANCELLED },
+    });
+
+    await createSystemMessage({
+      bookingId: updated.id,
+      senderId: userId,
+      receiverId: updated.providerId,
+      content: 'Le client a annul\u00e9 la r\u00e9servation.',
+    });
+
+    await notifyUser(updated.providerId, 'booking_cancelled', 'R\u00e9servation annul\u00e9e', 'Le client a annul\u00e9 la r\u00e9servation.', { bookingId: updated.id });
+
+    res.json({ success: true, data: { booking: updated } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function listBookings(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = parseInt(req.user?.id || '', 10);
+    const role = req.user?.role;
+    const page = parseInt((req.query.page as string) || '1', 10);
+    const size = Math.min(parseInt((req.query.size as string) || '10', 10), 50);
+    const skip = (page - 1) * size;
+
+    const where: any = {};
+    if (role === 'client') where.clientId = userId;
+    else if (role === 'provider') where.providerId = userId;
+
+    if (req.query.status) where.status = req.query.status as string;
+    if (req.query.day && isValidDay(req.query.day as string)) where.scheduledDay = req.query.day;
+
+    const [items, total] = await Promise.all([
+      prisma.booking.findMany({
+        where,
+        skip,
+        take: size,
+        orderBy: [{ scheduledDay: 'desc' }, { createdAt: 'desc' }],
+      }),
+      prisma.booking.count({ where }),
+    ]);
+
+    res.json({ success: true, data: { items, page, size, total } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getBooking(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const userId = parseInt(req.user?.id || '', 10);
+    const role = req.user?.role;
+
+    const booking = await prisma.booking.findUnique({ where: { id } });
+    if (!booking) return next({ status: 404, message: 'Booking not found' });
+
+    if (role !== 'admin' && booking.clientId !== userId && booking.providerId !== userId) {
+      return next({ status: 403, message: 'Forbidden' });
+    }
+
+    res.json({ success: true, data: { booking } });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/routes/bookings.ts
+++ b/backend/src/routes/bookings.ts
@@ -1,0 +1,53 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { authenticate, requireRole } from '../middlewares/auth';
+import { validate } from '../middlewares/validation';
+import {
+  createBooking,
+  confirmBooking,
+  proposeDay,
+  acceptReschedule,
+  rejectBooking,
+  cancelBooking,
+  listBookings,
+  getBooking,
+} from '../controllers/bookingController';
+
+const router = Router();
+
+const idSchema = z.object({ params: z.object({ id: z.string().regex(/^[0-9]+$/) }) });
+
+const createSchema = z.object({
+  body: z.object({
+    serviceId: z.number(),
+    title: z.string().min(3),
+    description: z.string().min(10),
+    scheduledDay: z.string(),
+    price: z.number().int().min(0).optional(),
+  }),
+});
+
+const proposeSchema = z.object({
+  params: idSchema.shape.params,
+  body: z.object({ proposedDay: z.string() }),
+});
+
+const listSchema = z.object({
+  query: z.object({
+    page: z.string().regex(/^[0-9]+$/).optional(),
+    size: z.string().regex(/^[0-9]+$/).optional(),
+    status: z.enum(['PENDING','CONFIRMED','RESCHEDULE_PROPOSED','CANCELLED','REJECTED','COMPLETED']).optional(),
+    day: z.string().optional(),
+  }),
+});
+
+router.post('/', authenticate, requireRole('client', 'admin'), validate(createSchema), createBooking);
+router.put('/:id/confirm', authenticate, requireRole('provider'), validate(idSchema), confirmBooking);
+router.put('/:id/propose-day', authenticate, requireRole('provider'), validate(proposeSchema), proposeDay);
+router.put('/:id/accept-reschedule', authenticate, requireRole('client'), validate(idSchema), acceptReschedule);
+router.put('/:id/reject', authenticate, requireRole('provider'), validate(idSchema), rejectBooking);
+router.put('/:id/cancel', authenticate, requireRole('client'), validate(idSchema), cancelBooking);
+router.get('/', authenticate, validate(listSchema), listBookings);
+router.get('/:id', authenticate, validate(idSchema), getBooking);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -9,6 +9,7 @@ import paymentRoutes from './routes/payments';
 import { handleStripeWebhook } from './controllers/paymentController';
 import providersRouter from './routes/providers';
 import servicesRouter from './routes/services';
+import bookingsRouter from './routes/bookings';
 
 const app = express();
 
@@ -27,6 +28,7 @@ app.use('/api/subscriptions', subscriptionRoutes);
 app.use('/api/payments', paymentRoutes);
 app.use('/api/providers', providersRouter);
 app.use('/api/services', servicesRouter);
+app.use('/api/bookings', bookingsRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/utils/day.ts
+++ b/backend/src/utils/day.ts
@@ -1,0 +1,9 @@
+export function isValidDay(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(s) && !Number.isNaN(new Date(s + 'T00:00:00Z').getTime());
+}
+export function isFutureOrTodayDay(s: string): boolean {
+  const today = new Date();
+  const tzToday = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
+  const d = new Date(s + 'T00:00:00Z');
+  return d.getTime() >= tzToday.getTime();
+}

--- a/backend/src/utils/messages.ts
+++ b/backend/src/utils/messages.ts
@@ -1,0 +1,17 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+export async function createSystemMessage({
+  bookingId, senderId, receiverId, content
+}: { bookingId?: number; senderId: number; receiverId: number; content: string; }) {
+  const hasIsSystem = (prisma as any).message?.fields?.isSystem !== undefined;
+  return prisma.message.create({
+    data: {
+      bookingId: bookingId ?? null,
+      senderId,
+      receiverId,
+      content,
+      ...(hasIsSystem ? { isSystem: true } : {})
+    }
+  });
+}

--- a/backend/src/utils/notify.ts
+++ b/backend/src/utils/notify.ts
@@ -1,0 +1,4 @@
+export async function notifyUser(userId: number, type: string, title: string, message: string, data?: any) {
+  // TODO: brancher table notifications ou service push
+  return { delivered: true };
+}


### PR DESCRIPTION
## Summary
- model bookings and messages in Prisma with day-only scheduling
- add booking utilities and notification stub
- implement booking CRUD endpoints with system messages

## Testing
- `npx prisma migrate dev --name bookings_day_chat && npx prisma generate`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897af8a40c88328af75cb720085f656