### PR TITLE
Add review model and API endpoints

### DIFF
--- a/backend/prisma/migrations/20250809211847_add_reviews/migration.sql
+++ b/backend/prisma/migrations/20250809211847_add_reviews/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "Review" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "bookingId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "rating" INTEGER NOT NULL,
+    "comment" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Review_bookingId_fkey" FOREIGN KEY ("bookingId") REFERENCES "Booking" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Review_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "Review_userId_idx" ON "Review"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uniq_review_booking_user" ON "Review"("bookingId", "userId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   providerBookings Booking[] @relation("providerBookings")
   sentMessages     Message[] @relation("MessageSender")
   receivedMessages Message[] @relation("MessageReceiver")
+  reviews          Review[]
 }
 
 model Subscription {
@@ -101,6 +102,7 @@ model Booking {
   service  Service @relation(fields: [serviceId], references: [id])
 
   messages Message[]
+  reviews  Review[]
 
   @@index([clientId, status], map: "idx_booking_client_status")
   @@index([providerId, status], map: "idx_booking_provider_status")
@@ -128,4 +130,20 @@ model Message {
   @@index([bookingId])
   @@index([senderId, receiverId, createdAt])
   @@index([receiverId, isRead, createdAt])
+}
+
+model Review {
+  id         Int      @id @default(autoincrement())
+  bookingId  Int
+  userId     Int
+  rating     Int
+  comment    String?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  booking    Booking  @relation(fields: [bookingId], references: [id])
+  user       User     @relation(fields: [userId], references: [id])
+
+  @@unique([bookingId, userId], map: "uniq_review_booking_user")
+  @@index([userId])
 }

--- a/backend/src/controllers/reviewController.ts
+++ b/backend/src/controllers/reviewController.ts
@@ -1,0 +1,172 @@
+import { Request, Response, NextFunction } from 'express';
+import { Prisma, PrismaClient } from '@prisma/client';
+import { notifyUser } from '../utils/notify';
+
+const prisma = new PrismaClient();
+
+export async function createReview(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = parseInt(req.user?.id || '', 10);
+    const { bookingId, rating, comment } = req.body as { bookingId: number; rating: number; comment?: string };
+
+    const booking = await prisma.booking.findUnique({
+      where: { id: bookingId },
+      select: { id: true, clientId: true, providerId: true, status: true },
+    });
+    if (!booking) return next({ status: 404, message: 'Booking not found' });
+    if (booking.clientId !== userId) return next({ status: 403, message: 'Forbidden' });
+    if (booking.status !== 'COMPLETED') return next({ status: 409, message: 'Booking not completed' });
+
+    try {
+      const review = await prisma.$transaction(async (tx) => {
+        const created = await tx.review.create({
+          data: { bookingId, userId, rating, comment },
+        });
+
+        const agg = await tx.review.aggregate({
+          where: { booking: { providerId: booking.providerId } },
+          _avg: { rating: true },
+          _count: { rating: true },
+        });
+
+        await tx.provider.update({
+          where: { userId: booking.providerId },
+          data: {
+            rating: Number((agg._avg.rating || 0).toFixed(1)),
+            reviewCount: agg._count.rating,
+          },
+        });
+
+        return created;
+      });
+
+      await notifyUser(
+        booking.providerId,
+        'review_created',
+        'Nouvel avis',
+        'Vous avez reçu un nouvel avis',
+        { reviewId: review.id }
+      );
+
+      res.status(201).json({ success: true, data: { review } });
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+        return next({ status: 409, message: 'Review already exists' });
+      }
+      throw err;
+    }
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function listProviderReviews(req: Request, res: Response, next: NextFunction) {
+  try {
+    const providerId = parseInt(req.params.providerId, 10);
+    const page = parseInt((req.query.page as string) || '1', 10);
+    const size = Math.min(parseInt((req.query.size as string) || '10', 10), 50);
+    const skip = (page - 1) * size;
+
+    const where = { booking: { providerId } };
+
+    const [items, total] = await Promise.all([
+      prisma.review.findMany({
+        where,
+        include: { user: true, booking: true },
+        skip,
+        take: size,
+        orderBy: { createdAt: 'desc' },
+      }),
+      prisma.review.count({ where }),
+    ]);
+
+    res.json({ success: true, data: { items, page, size, total } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateReview(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const { rating, comment } = req.body as { rating?: number; comment?: string };
+    const userId = parseInt(req.user?.id || '', 10);
+    const role = req.user?.role;
+
+    const existing = await prisma.review.findUnique({
+      where: { id },
+      include: { booking: true },
+    });
+    if (!existing) return next({ status: 404, message: 'Review not found' });
+    if (existing.userId !== userId && role !== 'admin') return next({ status: 403, message: 'Forbidden' });
+
+    const providerId = existing.booking.providerId;
+
+    const review = await prisma.$transaction(async (tx) => {
+      const updated = await tx.review.update({
+        where: { id },
+        data: { rating, comment },
+      });
+
+      const agg = await tx.review.aggregate({
+        where: { booking: { providerId } },
+        _avg: { rating: true },
+        _count: { rating: true },
+      });
+
+      await tx.provider.update({
+        where: { userId: providerId },
+        data: {
+          rating: Number((agg._avg.rating || 0).toFixed(1)),
+          reviewCount: agg._count.rating,
+        },
+      });
+
+      return updated;
+    });
+
+    res.json({ success: true, data: { review } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteReview(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const userId = parseInt(req.user?.id || '', 10);
+    const role = req.user?.role;
+
+    const existing = await prisma.review.findUnique({
+      where: { id },
+      include: { booking: true },
+    });
+    if (!existing) return next({ status: 404, message: 'Review not found' });
+    if (existing.userId !== userId && role !== 'admin') return next({ status: 403, message: 'Forbidden' });
+
+    const providerId = existing.booking.providerId;
+
+    await prisma.$transaction(async (tx) => {
+      await tx.review.delete({ where: { id } });
+
+      const agg = await tx.review.aggregate({
+        where: { booking: { providerId } },
+        _avg: { rating: true },
+        _count: { rating: true },
+      });
+
+      await tx.provider.update({
+        where: { userId: providerId },
+        data: {
+          rating: Number((agg._avg.rating || 0).toFixed(1)),
+          reviewCount: agg._count.rating,
+        },
+      });
+    });
+
+    res.json({ success: true });
+  } catch (err) {
+    next(err);
+  }
+}
+

--- a/backend/src/routes/reviews.ts
+++ b/backend/src/routes/reviews.ts
@@ -1,0 +1,49 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { authenticate } from '../middlewares/auth';
+import { validate } from '../middlewares/validation';
+import {
+  createReview,
+  listProviderReviews,
+  updateReview,
+  deleteReview,
+} from '../controllers/reviewController';
+
+const router = Router();
+
+const createSchema = z.object({
+  body: z.object({
+    bookingId: z.number().int(),
+    rating: z.number().int().min(1).max(5),
+    comment: z.string().max(1000).optional(),
+  }),
+});
+
+const providerSchema = z.object({
+  params: z.object({ providerId: z.string().regex(/^[0-9]+$/) }),
+  query: z.object({
+    page: z.string().regex(/^[0-9]+$/).optional(),
+    size: z.string().regex(/^[0-9]+$/).optional(),
+  }),
+});
+
+const idSchema = z.object({ params: z.object({ id: z.string().regex(/^[0-9]+$/) }) });
+
+const updateSchema = z.object({
+  params: idSchema.shape.params,
+  body: z
+    .object({
+      rating: z.number().int().min(1).max(5).optional(),
+      comment: z.string().max(1000).optional(),
+    })
+    .refine((data) => data.rating !== undefined || data.comment !== undefined, {
+      message: 'At least one field must be provided',
+    }),
+});
+
+router.post('/', authenticate, validate(createSchema), createReview);
+router.get('/provider/:providerId', validate(providerSchema), listProviderReviews);
+router.put('/:id', authenticate, validate(updateSchema), updateReview);
+router.delete('/:id', authenticate, validate(idSchema), deleteReview);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -11,6 +11,7 @@ import providersRouter from './routes/providers';
 import servicesRouter from './routes/services';
 import bookingsRouter from './routes/bookings';
 import messagesRouter from './routes/messages';
+import reviewsRouter from './routes/reviews';
 
 const app = express();
 
@@ -31,6 +32,7 @@ app.use('/api/providers', providersRouter);
 app.use('/api/services', servicesRouter);
 app.use('/api/bookings', bookingsRouter);
 app.use('/api/messages', messagesRouter);
+app.use('/api/reviews', reviewsRouter);
 
 app.use(errorHandler);
 


### PR DESCRIPTION
## Summary
- add Review table and link to users and bookings
- expose CRUD endpoints for reviews with validation and auth
- update provider rating and count in transactions and notify on new review

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897b9cf6e848328b026beb69d9aac69