### PR TITLE
feat: add audit logging and admin stats

### DIFF
--- a/backend/prisma/migrations/20250809220430_add_auditlog/migration.sql
+++ b/backend/prisma/migrations/20250809220430_add_auditlog/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "userId" INTEGER,
+    "action" TEXT NOT NULL,
+    "resource" TEXT NOT NULL,
+    "resourceId" INTEGER,
+    "oldValues" TEXT,
+    "newValues" TEXT,
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "AuditLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'CLIENT',
+    "isVerified" BOOLEAN NOT NULL DEFAULT true,
+    "isDisabled" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "phone" TEXT,
+    "phoneVerified" BOOLEAN NOT NULL DEFAULT false,
+    "smsOptIn" BOOLEAN NOT NULL DEFAULT false,
+    "preferredLang" TEXT
+);
+INSERT INTO "new_User" ("createdAt", "email", "id", "isVerified", "password", "phone", "phoneVerified", "preferredLang", "role", "smsOptIn", "updatedAt") SELECT "createdAt", "email", "id", "isVerified", "password", "phone", "phoneVerified", "preferredLang", "role", "smsOptIn", "updatedAt" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE INDEX "AuditLog_resource_resourceId_idx" ON "AuditLog"("resource", "resourceId");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_createdAt_idx" ON "AuditLog"("createdAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   password      String
   role          String         @default("CLIENT")
   isVerified    Boolean        @default(true)
+  isDisabled    Boolean        @default(false)
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
   subscriptions Subscription[]
@@ -31,6 +32,7 @@ model User {
   phoneVerified Boolean  @default(false)
   smsOptIn      Boolean  @default(false)
   preferredLang String?
+  auditLogs     AuditLog[]
 }
 
 model Subscription {
@@ -203,4 +205,21 @@ model SmsMessage {
 
   @@index([userId, createdAt], map: "idx_sms_user_date")
   @@unique([userId, bookingId, type], map: "uniq_sms_once_per_event")
+}
+
+model AuditLog {
+  id         Int      @id @default(autoincrement())
+  userId     Int?
+  action     String
+  resource   String
+  resourceId Int?
+  oldValues  String?
+  newValues  String?
+  ipAddress  String?
+  userAgent  String?
+  createdAt  DateTime @default(now())
+  user       User?    @relation(fields: [userId], references: [id])
+
+  @@index([resource, resourceId])
+  @@index([createdAt])
 }

--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -1,0 +1,90 @@
+import { Request, Response, NextFunction } from 'express';
+import { PrismaClient, Prisma } from '@prisma/client';
+import { logAction } from '../middlewares/audit';
+
+const prisma = new PrismaClient();
+
+export async function deleteReview(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const existing = await prisma.review.findUnique({
+      where: { id },
+      include: { booking: true },
+    });
+    if (!existing) return next({ status: 404, message: 'Review not found' });
+
+    const providerId = existing.booking.providerId;
+
+    await prisma.$transaction(async (tx) => {
+      await tx.review.delete({ where: { id } });
+      const agg = await tx.review.aggregate({
+        where: { booking: { providerId } },
+        _avg: { rating: true },
+        _count: { rating: true },
+      });
+      await tx.provider.update({
+        where: { userId: providerId },
+        data: {
+          rating: Number((agg._avg.rating || 0).toFixed(1)),
+          reviewCount: agg._count.rating,
+        },
+      });
+    });
+
+    await logAction({
+      userId: parseInt(req.user?.id || '0', 10),
+      action: 'DELETE_REVIEW',
+      resource: 'review',
+      resourceId: id,
+      oldValues: { rating: existing.rating, comment: existing.comment },
+      ip: req.ip,
+      ua: req.headers['user-agent'],
+    });
+
+    res.json({ success: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function disableUser(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const existing = await prisma.user.findUnique({ where: { id } });
+    if (!existing) return next({ status: 404, message: 'User not found' });
+
+    await prisma.user.update({ where: { id }, data: { isDisabled: true } });
+
+    await logAction({
+      userId: parseInt(req.user?.id || '0', 10),
+      action: 'DISABLE_USER',
+      resource: 'user',
+      resourceId: id,
+      oldValues: { isDisabled: existing.isDisabled },
+      newValues: { isDisabled: true },
+      ip: req.ip,
+      ua: req.headers['user-agent'],
+    });
+
+    res.json({ success: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function listAuditLogs(req: Request, res: Response, next: NextFunction) {
+  try {
+    const page = parseInt((req.query.page as string) || '1', 10);
+    const size = Math.min(parseInt((req.query.size as string) || '10', 10), 100);
+    const skip = (page - 1) * size;
+
+    const [items, total] = await Promise.all([
+      prisma.auditLog.findMany({ skip, take: size, orderBy: { createdAt: 'desc' } }),
+      prisma.auditLog.count(),
+    ]);
+
+    res.json({ success: true, data: { items, page, size, total } });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -51,6 +51,10 @@ export async function login(req: Request, res: Response, next: NextFunction) {
       return next({ status: 401, message: 'Invalid credentials' });
     }
 
+    if (user.isDisabled) {
+      return next({ status: 403, message: 'Account disabled' });
+    }
+
     const valid = await verifyPassword(password, user.password);
     if (!valid) {
       return next({ status: 401, message: 'Invalid credentials' });

--- a/backend/src/controllers/statsController.ts
+++ b/backend/src/controllers/statsController.ts
@@ -1,0 +1,75 @@
+import { Request, Response, NextFunction } from 'express';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function adminStats(_req: Request, res: Response, next: NextFunction) {
+  try {
+    const [users, providers, activeSubscriptions] = await Promise.all([
+      prisma.user.count(),
+      prisma.provider.count(),
+      prisma.subscription.count({ where: { status: 'ACTIVE' } }),
+    ]);
+
+    const bookingsByStatus = await prisma.booking.groupBy({
+      by: ['status'],
+      _count: { _all: true },
+    });
+
+    const topCategories = await prisma.service.groupBy({
+      by: ['category'],
+      _count: { category: true },
+      orderBy: { _count: { category: 'desc' } },
+      take: 5,
+    });
+
+    res.json({
+      success: true,
+      data: { users, providers, bookingsByStatus, topCategories, activeSubscriptions },
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function providerStats(req: Request, res: Response, next: NextFunction) {
+  try {
+    const providerUserId = parseInt(req.params.providerUserId, 10);
+    const now = new Date();
+    const since = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+    const [totalBookings, last30Days, acceptedBookings, times, provider] = await Promise.all([
+      prisma.booking.count({ where: { providerId: providerUserId } }),
+      prisma.booking.count({ where: { providerId: providerUserId, createdAt: { gte: since } } }),
+      prisma.booking.count({ where: { providerId: providerUserId, status: { in: ['CONFIRMED', 'COMPLETED'] } } }),
+      prisma.booking.findMany({
+        where: { providerId: providerUserId, status: { in: ['CONFIRMED', 'COMPLETED'] } },
+        select: { createdAt: true, updatedAt: true },
+      }),
+      prisma.provider.findUnique({ where: { userId: providerUserId }, select: { rating: true, reviewCount: true } }),
+    ]);
+
+    const acceptanceRate = totalBookings === 0 ? 0 : Math.round((acceptedBookings / totalBookings) * 100);
+    const avgResponseTime =
+      times.length === 0
+        ? 0
+        : times.reduce((sum, t) => sum + (t.updatedAt.getTime() - t.createdAt.getTime()), 0) /
+          times.length /
+          1000 /
+          60;
+
+    res.json({
+      success: true,
+      data: {
+        totalBookings,
+        last30Days,
+        acceptanceRate,
+        avgResponseTime,
+        rating: provider?.rating ?? 0,
+        reviewCount: provider?.reviewCount ?? 0,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/middlewares/audit.ts
+++ b/backend/src/middlewares/audit.ts
@@ -1,0 +1,44 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+interface LogParams {
+  userId?: number;
+  action: string;
+  resource: string;
+  resourceId?: number;
+  oldValues?: any;
+  newValues?: any;
+  ip?: string;
+  ua?: string | string[];
+}
+
+export async function logAction({
+  userId,
+  action,
+  resource,
+  resourceId,
+  oldValues,
+  newValues,
+  ip,
+  ua,
+}: LogParams) {
+  try {
+    await prisma.auditLog.create({
+      data: {
+        userId,
+        action,
+        resource,
+        resourceId,
+        oldValues: oldValues ? JSON.stringify(oldValues) : undefined,
+        newValues: newValues ? JSON.stringify(newValues) : undefined,
+        ipAddress: ip,
+        userAgent: typeof ua === 'string' ? ua : Array.isArray(ua) ? ua.join(',') : undefined,
+      },
+    });
+  } catch (err) {
+    console.error('Audit log failed', err);
+  }
+}
+
+export default logAction;

--- a/backend/src/middlewares/errorHandler.ts
+++ b/backend/src/middlewares/errorHandler.ts
@@ -1,15 +1,32 @@
 import { Request, Response, NextFunction } from 'express';
+import { Prisma } from '@prisma/client';
 
 export function errorHandler(err: any, _req: Request, res: Response, _next: NextFunction) {
-  const status = err?.status || 500;
-  const message = err?.message || 'Internal Server Error';
+  let status = err?.status || 500;
+  let message = err?.message || 'Internal Server Error';
+
+  if (err instanceof Prisma.PrismaClientKnownRequestError) {
+    switch (err.code) {
+      case 'P2002':
+        status = 409;
+        message = 'Unique constraint failed';
+        break;
+      case 'P2025':
+        status = 404;
+        message = 'Record not found';
+        break;
+      default:
+        status = 400;
+        message = 'Database error';
+    }
+  }
 
   res.status(status).json({
     success: false,
     error: {
       code: status,
       message,
-      timestamp: new Date().toISOString()
-    }
+      timestamp: new Date().toISOString(),
+    },
   });
 }

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { deleteReview, disableUser, listAuditLogs } from '../controllers/adminController';
+
+const router = Router();
+
+router.delete('/reviews/:id', deleteReview);
+router.put('/users/:id/disable', disableUser);
+router.get('/audit', listAuditLogs);
+
+export default router;

--- a/backend/src/routes/stats.ts
+++ b/backend/src/routes/stats.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { adminStats, providerStats } from '../controllers/statsController';
+import { authenticate, requireRole } from '../middlewares/auth';
+
+const router = Router();
+
+router.get('/admin', authenticate, requireRole('admin'), adminStats);
+router.get('/provider/:providerUserId', authenticate, providerStats);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -15,14 +15,43 @@ import reviewsRouter from './routes/reviews';
 import favoritesRouter from './routes/favorites';
 import notificationsRouter from './routes/notifications';
 import smsRouter from './routes/sms';
+import adminRouter from './routes/admin';
+import statsRouter from './routes/stats';
+import { authenticate, requireRole } from './middlewares/auth';
 
 const app = express();
 
 app.post('/api/payments/webhook', express.raw({ type: 'application/json' }), handleStripeWebhook);
 
 app.use(express.json());
-app.use(helmet());
-app.use(cors({ origin: env.frontendUrl }));
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      useDefaults: true,
+      directives: {
+        "img-src": ["'self'", 'data:', 'https:'],
+        "script-src": ["'self'", "'unsafe-inline'"],
+        "connect-src": ["'self'", env.frontendUrl],
+      },
+    },
+    crossOriginResourcePolicy: { policy: 'cross-origin' },
+  })
+);
+app.use(
+  cors({
+    origin: env.frontendUrl,
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
+    credentials: false,
+  })
+);
+
+if (process.env.NODE_ENV === 'production') {
+  app.set('trust proxy', 1);
+  app.use((req, res, next) => {
+    if (req.secure || req.headers['x-forwarded-proto'] === 'https') return next();
+    res.redirect('https://' + req.headers.host + req.url);
+  });
+}
 
 app.get('/health', (_req, res) => {
   res.json({ success: true });
@@ -39,6 +68,8 @@ app.use('/api/reviews', reviewsRouter);
 app.use('/api/favorites', favoritesRouter);
 app.use('/api/notifications', notificationsRouter);
 app.use('/api/sms', smsRouter);
+app.use('/api/admin', authenticate, requireRole('admin'), adminRouter);
+app.use('/api/stats', statsRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/utils/upload.ts
+++ b/backend/src/utils/upload.ts
@@ -1,12 +1,13 @@
 import multer, { FileFilterCallback } from './multer';
 import fs from 'fs';
 import path from 'path';
+import { randomUUID } from 'crypto';
 import type { Request } from 'express';
 
 const uploadPath = process.env.UPLOAD_PATH || './uploads';
 
 if (!fs.existsSync(uploadPath)) {
-  fs.mkdirSync(uploadPath, { recursive: true });
+  fs.mkdirSync(uploadPath, { recursive: true, mode: 0o700 });
 }
 
 const storage = multer.diskStorage({
@@ -22,7 +23,7 @@ const storage = multer.diskStorage({
     file: any,
     cb: (error: Error | null, filename: string) => void,
   ) => {
-    const unique = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+    const unique = randomUUID();
     cb(null, unique + path.extname(file.originalname));
   },
 });


### PR DESCRIPTION
## Summary
- track user actions with new `AuditLog` model and helper
- add admin controls for review moderation, user disabling and audit review
- expose admin and provider stats endpoints with security hardening

## Testing
- `DATABASE_URL="file:./dev.db" npx prisma migrate dev --name add_auditlog`
- `DATABASE_URL="file:./dev.db" npx prisma generate`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897c43308908328aedcb71c3718fe47