### PR TITLE
Add backend Jest tests for auth and booking flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ vite.config.ts.*
 **/.env
 **/dev.db
 **/dev.db-journal
+**/test.db
+**/test.db-journal

--- a/backend/.env.test
+++ b/backend/.env.test
@@ -1,0 +1,6 @@
+NODE_ENV=test
+PORT=0
+DATABASE_URL="file:./test.db"
+FRONTEND_URL=http://localhost:5173
+JWT_SECRET="test_secret_32_chars_minimum____________"
+JWT_REFRESH_SECRET="test_refresh_secret_32_chars_minimum"

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,7 +1,7 @@
-export default {
+module.exports = {
   testEnvironment: 'node',
   transform: { '^.+\\.tsx?$': ['ts-jest', {}] },
   testMatch: ['**/__tests__/**/*.test.ts'],
-  moduleFileExtensions: ['ts','tsx','js'],
-  verbose: true
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  verbose: true,
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,9 @@
     "db:migrate": "echo \"db migrate not implemented\"",
     "db:seed": "echo \"db seed not implemented\"",
     "db:generate": "npx prisma generate",
+    "db:test:reset": "prisma db push --force-reset --accept-data-loss",
     "test": "jest",
+    "test:db": "npm run db:test:reset && npm test",
     "test:watch": "jest --watch",
     "e2e:clubpro:curl": "node scripts/print-e2e-curls.js"
   },

--- a/backend/src/__tests__/auth.test.ts
+++ b/backend/src/__tests__/auth.test.ts
@@ -1,9 +1,23 @@
+import '../test/env';
 import request from 'supertest';
 import { app } from '../server';
 
-describe('auth flow', () => {
-  it('placeholder', async () => {
-    const res = await request(app).get('/health');
-    expect(res.status).toBe(200);
+describe('Auth', () => {
+  it('register + login + profile', async () => {
+    const email = `t${Date.now()}@test.io`;
+    await request(app)
+      .post('/api/auth/register')
+      .send({ email, password: 'Passw0rd!', role: 'CLIENT' })
+      .expect(201);
+    const { body } = await request(app)
+      .post('/api/auth/login')
+      .send({ email, password: 'Passw0rd!' })
+      .expect(200);
+    const token = body?.data?.accessToken;
+    expect(token).toBeDefined();
+    await request(app)
+      .get('/api/auth/profile')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
   });
 });

--- a/backend/src/__tests__/bookings.test.ts
+++ b/backend/src/__tests__/bookings.test.ts
@@ -1,9 +1,61 @@
+import '../test/env';
 import request from 'supertest';
 import { app } from '../server';
 
-describe('bookings flow', () => {
-  it('placeholder', async () => {
-    const res = await request(app).get('/health');
-    expect(res.body.status).toBe('ok');
+function dayPlus(n: number) {
+  const d = new Date();
+  d.setDate(d.getDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+describe('Booking flow', () => {
+  it('client create pending -> provider confirm', async () => {
+    const pEmail = `p${Date.now()}@test.io`;
+    const cEmail = `c${Date.now()}@test.io`;
+
+    await request(app)
+      .post('/api/auth/register')
+      .send({ email: pEmail, password: 'Passw0rd!', role: 'PROVIDER' })
+      .expect(201);
+    await request(app)
+      .post('/api/auth/register')
+      .send({ email: cEmail, password: 'Passw0rd!', role: 'CLIENT' })
+      .expect(201);
+
+    const pLogin = await request(app)
+      .post('/api/auth/login')
+      .send({ email: pEmail, password: 'Passw0rd!' })
+      .expect(200);
+    const cLogin = await request(app)
+      .post('/api/auth/login')
+      .send({ email: cEmail, password: 'Passw0rd!' })
+      .expect(200);
+
+    const pToken = pLogin.body.data.accessToken;
+    const cToken = cLogin.body.data.accessToken;
+
+    await request(app)
+      .post('/api/providers')
+      .set('Authorization', `Bearer ${pToken}`)
+      .send({ bio: 'pro' })
+      .expect(201);
+    const svc = await request(app)
+      .post('/api/services')
+      .set('Authorization', `Bearer ${pToken}`)
+      .send({ name: 'Plomberie', category: 'plumbing', basePrice: 1000, description: 'fix' })
+      .expect(201);
+    const serviceId = svc.body.data.service.id;
+
+    const b1 = await request(app)
+      .post('/api/bookings')
+      .set('Authorization', `Bearer ${cToken}`)
+      .send({ serviceId, title: 'Fix', description: 'Robinet qui fuit', scheduledDay: dayPlus(2) })
+      .expect(201);
+    const bookingId = b1.body.data.booking.id;
+
+    await request(app)
+      .put(`/api/bookings/${bookingId}/confirm`)
+      .set('Authorization', `Bearer ${pToken}`)
+      .expect(200);
   });
 });

--- a/backend/src/test/env.ts
+++ b/backend/src/test/env.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const envPath = path.resolve(__dirname, '../../.env.test');
+if (fs.existsSync(envPath)) {
+  const lines = fs.readFileSync(envPath, 'utf8').split('\n').filter(Boolean);
+  for (const line of lines) {
+    const m = /^([^#=]+)=(.*)$/.exec(line.trim());
+    if (m) {
+      const key = m[1].trim();
+      let value = m[2].trim();
+      if (value.startsWith('"') && value.endsWith('"')) {
+        value = value.slice(1, -1);
+      }
+      process.env[key] = value;
+    }
+  }
+}

--- a/backend/src/types/sentry.d.ts
+++ b/backend/src/types/sentry.d.ts
@@ -1,0 +1,1 @@
+declare module '@sentry/node';


### PR DESCRIPTION
## Summary
- add backend test env and scripts for db reset
- convert Jest config to JS and stub @sentry/node types
- add auth and booking flow tests using supertest

## Testing
- `npm run db:test:reset`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897cb8c87448328af51ef944c285269