### PR TITLE
Add backend jest setup and flow tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ vite.config.ts.*
 **/dev.db-journal
 **/test.db
 **/test.db-journal
+
+*.test.db
+test.db

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,6 +2,9 @@ module.exports = {
   testEnvironment: 'node',
   transform: { '^.+\\.tsx?$': ['ts-jest', {}] },
   testMatch: ['**/__tests__/**/*.test.ts'],
+  setupFilesAfterEnv: ['<rootDir>/src/__tests__/jest.setup.ts'],
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/types.ts'],
   moduleFileExtensions: ['ts', 'tsx', 'js'],
-  verbose: true,
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,8 @@
     "test": "jest",
     "test:db": "npm run db:test:reset && npm test",
     "test:watch": "jest --watch",
-    "e2e:clubpro:curl": "node scripts/print-e2e-curls.js"
+    "e2e:clubpro:curl": "node scripts/print-e2e-curls.js",
+    "test:cov": "jest --coverage"
   },
   "dependencies": {
     "@prisma/client": "^5.16.1",

--- a/backend/src/__tests__/bookings.test.ts
+++ b/backend/src/__tests__/bookings.test.ts
@@ -9,7 +9,7 @@ function dayPlus(n: number) {
 }
 
 describe('Booking flow', () => {
-  it('client create pending -> provider confirm', async () => {
+  it('client create -> provider confirm -> propose day -> client accept', async () => {
     const pEmail = `p${Date.now()}@test.io`;
     const cEmail = `c${Date.now()}@test.io`;
 
@@ -56,6 +56,18 @@ describe('Booking flow', () => {
     await request(app)
       .put(`/api/bookings/${bookingId}/confirm`)
       .set('Authorization', `Bearer ${pToken}`)
+      .expect(200);
+
+    const newDay = dayPlus(3);
+    await request(app)
+      .put(`/api/bookings/${bookingId}/propose-day`)
+      .set('Authorization', `Bearer ${pToken}`)
+      .send({ proposedDay: newDay })
+      .expect(200);
+
+    await request(app)
+      .put(`/api/bookings/${bookingId}/accept-reschedule`)
+      .set('Authorization', `Bearer ${cToken}`)
       .expect(200);
   });
 });

--- a/backend/src/__tests__/favorites.test.ts
+++ b/backend/src/__tests__/favorites.test.ts
@@ -1,0 +1,57 @@
+import '../test/env';
+import request from 'supertest';
+import { app } from '../server';
+
+describe('favorites flow', () => {
+  it('add/check/idempotent/delete', async () => {
+    const pEmail = `p${Date.now()}@test.io`;
+    const cEmail = `c${Date.now()}@test.io`;
+
+    await request(app).post('/api/auth/register').send({ email: pEmail, password: 'Passw0rd!', role: 'PROVIDER' }).expect(201);
+    await request(app).post('/api/auth/register').send({ email: cEmail, password: 'Passw0rd!', role: 'CLIENT' }).expect(201);
+
+    const pLogin = await request(app).post('/api/auth/login').send({ email: pEmail, password: 'Passw0rd!' }).expect(200);
+    const cLogin = await request(app).post('/api/auth/login').send({ email: cEmail, password: 'Passw0rd!' }).expect(200);
+    const pToken = pLogin.body.data.accessToken;
+    const cToken = cLogin.body.data.accessToken;
+
+    await request(app).post('/api/providers').set('Authorization', `Bearer ${pToken}`).send({ bio: 'pro' }).expect(201);
+
+    // add favorite
+    await request(app)
+      .post('/api/favorites')
+      .set('Authorization', `Bearer ${cToken}`)
+      .send({ providerId: pLogin.body.data.user.id })
+      .expect(201);
+
+    const check = await request(app)
+      .get(`/api/favorites/check/${pLogin.body.data.user.id}`)
+      .set('Authorization', `Bearer ${cToken}`)
+      .expect(200);
+    expect(check.body.data.isFavorite).toBe(true);
+
+    // idempotent add
+    await request(app)
+      .post('/api/favorites')
+      .set('Authorization', `Bearer ${cToken}`)
+      .send({ providerId: pLogin.body.data.user.id })
+      .expect(200);
+
+    const list = await request(app)
+      .get('/api/favorites')
+      .set('Authorization', `Bearer ${cToken}`)
+      .expect(200);
+    expect(list.body.data.items).toHaveLength(1);
+
+    await request(app)
+      .delete(`/api/favorites/${pLogin.body.data.user.id}`)
+      .set('Authorization', `Bearer ${cToken}`)
+      .expect(200);
+
+    const check2 = await request(app)
+      .get(`/api/favorites/check/${pLogin.body.data.user.id}`)
+      .set('Authorization', `Bearer ${cToken}`)
+      .expect(200);
+    expect(check2.body.data.isFavorite).toBe(false);
+  });
+});

--- a/backend/src/__tests__/jest.setup.ts
+++ b/backend/src/__tests__/jest.setup.ts
@@ -1,0 +1,2 @@
+jest.mock('../services/sms', () => ({ sendSMS: jest.fn(async () => ({ ok: true })) }));
+jest.mock('../services/notifications', () => ({ createNotification: jest.fn(async () => ({ id: 1 })) }));

--- a/backend/src/__tests__/messages.test.ts
+++ b/backend/src/__tests__/messages.test.ts
@@ -1,9 +1,48 @@
+import '../test/env';
 import request from 'supertest';
 import { app } from '../server';
 
 describe('messages flow', () => {
-  it('placeholder', async () => {
-    const res = await request(app).get('/health');
-    expect(res.body.uptime).toBeGreaterThanOrEqual(0);
+  it('send, list, mark read, ownership', async () => {
+    const aEmail = `a${Date.now()}@test.io`;
+    const bEmail = `b${Date.now()}@test.io`;
+
+    await request(app).post('/api/auth/register').send({ email: aEmail, password: 'Passw0rd!', role: 'CLIENT' }).expect(201);
+    await request(app).post('/api/auth/register').send({ email: bEmail, password: 'Passw0rd!', role: 'PROVIDER' }).expect(201);
+
+    const aLogin = await request(app).post('/api/auth/login').send({ email: aEmail, password: 'Passw0rd!' }).expect(200);
+    const bLogin = await request(app).post('/api/auth/login').send({ email: bEmail, password: 'Passw0rd!' }).expect(200);
+    const aToken = aLogin.body.data.accessToken;
+    const bToken = bLogin.body.data.accessToken;
+
+    const msg = await request(app)
+      .post('/api/messages')
+      .set('Authorization', `Bearer ${aToken}`)
+      .send({ receiverId: bLogin.body.data.user.id, content: 'hello' })
+      .expect(201);
+    const messageId = msg.body.data.message.id;
+
+    const unread = await request(app)
+      .get('/api/messages/unread-count')
+      .set('Authorization', `Bearer ${bToken}`)
+      .expect(200);
+    expect(unread.body.data.unreadTotal).toBe(1);
+
+    const conv = await request(app)
+      .get(`/api/messages/conversation/${aLogin.body.data.user.id}?markAsRead=true`)
+      .set('Authorization', `Bearer ${bToken}`)
+      .expect(200);
+    expect(conv.body.data.items).toHaveLength(1);
+
+    const unread2 = await request(app)
+      .get('/api/messages/unread-count')
+      .set('Authorization', `Bearer ${bToken}`)
+      .expect(200);
+    expect(unread2.body.data.unreadTotal).toBe(0);
+
+    await request(app)
+      .put(`/api/messages/${messageId}/read`)
+      .set('Authorization', `Bearer ${aToken}`)
+      .expect(403);
   });
 });

--- a/backend/src/__tests__/stats.test.ts
+++ b/backend/src/__tests__/stats.test.ts
@@ -1,0 +1,29 @@
+import '../test/env';
+import request from 'supertest';
+import { app } from '../server';
+
+describe('stats admin', () => {
+  it('allows admin only', async () => {
+    const adminEmail = `a${Date.now()}@test.io`;
+    const userEmail = `u${Date.now()}@test.io`;
+
+    await request(app).post('/api/auth/register').send({ email: adminEmail, password: 'Passw0rd!', role: 'ADMIN' }).expect(201);
+    await request(app).post('/api/auth/register').send({ email: userEmail, password: 'Passw0rd!', role: 'CLIENT' }).expect(201);
+
+    const adminLogin = await request(app).post('/api/auth/login').send({ email: adminEmail, password: 'Passw0rd!' }).expect(200);
+    const userLogin = await request(app).post('/api/auth/login').send({ email: userEmail, password: 'Passw0rd!' }).expect(200);
+
+    const adminToken = adminLogin.body.data.accessToken;
+    const userToken = userLogin.body.data.accessToken;
+
+    await request(app)
+      .get('/api/stats/admin')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+
+    await request(app)
+      .get('/api/stats/admin')
+      .set('Authorization', `Bearer ${userToken}`)
+      .expect(403);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure test sqlite databases are ignored
- configure Jest with setup mocks and coverage
- add favorites, messages, bookings reschedule and admin stats tests

## Testing
- `DATABASE_URL="file:./test.db" npm run db:test:reset`
- `DATABASE_URL="file:./test.db" npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897d26990288328ab218d0d5bc12324