### PR TITLE
feat: add KYC utility scripts and E2E flow

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -64,7 +64,7 @@ KYC_STORE_RAW=true
 
 # Keyring de chiffrement (master keys hex 32 bytes = 64 hex chars)
 # Exemple: {"k1":"<64 hex>"}
-KYC_ENC_KEYRING_JSON={"k1":"REPLACE_WITH_HEX_64"}
+KYC_ENC_KEYRING_JSON={"k1":"20150a6d3769133268174a11409575f9ca08b1630d7d9614690e01325c37fe22"}
 KYC_ENC_ACTIVE_KEY_ID=k1
 KYC_ENC_ROTATE_AFTER_DAYS=180
 
@@ -74,4 +74,4 @@ KYC_RAW_RETENTION_DAYS=365
 # Export légal: sécurité
 KYC_EXPORT_IP_ALLOWLIST=127.0.0.1,::1
 KYC_EXPORT_RATE_LIMIT=5:15m        # 5 requêtes par 15 minutes
-ADMIN_TOTP_REQUIRED=true           # exige OTP admin (si 2FA disponible)
+ADMIN_TOTP_REQUIRED=false          # exige OTP admin (si 2FA disponible)

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,11 @@
     "test:watch": "jest --watch",
     "e2e:clubpro:curl": "node scripts/print-e2e-curls.js",
     "test:cov": "jest --coverage",
-    "admin:create": "ts-node scripts/create-admin.ts"
+    "admin:create": "ts-node scripts/create-admin.ts",
+    "admin:ensure:dev": "ts-node scripts/dev-ensure-admins.ts",
+    "vault:check": "ts-node scripts/check-vault.ts",
+    "kyc:retention:run": "ts-node scripts/run-kyc-retention.ts",
+    "e2e:optionB": "bash scripts/e2e-optionB.sh"
   },
   "dependencies": {
     "@prisma/client": "^5.16.1",

--- a/backend/scripts/check-vault.ts
+++ b/backend/scripts/check-vault.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+(async ()=>{
+  const userId = Number(process.argv[2]);
+  if (!userId) throw new Error('Usage: ts-node scripts/check-vault.ts <userId>');
+  const v = await prisma.kycVault.findUnique({ where:{ userId }});
+  console.log({ userId, hasCipher: !!(v?.encDoc && v.encDocTag && v.encDocNonce), keyId: v?.keyId, updatedAt: v?.updatedAt });
+  process.exit(0);
+})().catch(e=>{ console.error(e); process.exit(1); });

--- a/backend/scripts/dev-ensure-admins.ts
+++ b/backend/scripts/dev-ensure-admins.ts
@@ -1,0 +1,20 @@
+import { PrismaClient } from '@prisma/client';
+import { hashPassword } from '../src/utils/password';
+const prisma = new PrismaClient();
+
+async function upsertAdmin(email:string, pass:string, firstName:string) {
+  const hashed = await hashPassword(pass);
+  const found = await prisma.user.findUnique({ where: { email }});
+  if (!found) {
+    await prisma.user.create({ data: { email, password: hashed, firstName, lastName:'Admin', role:'ADMIN', isVerified:true }});
+  } else if (found.role !== 'ADMIN') {
+    await prisma.user.update({ where:{ id:found.id }, data:{ role:'ADMIN', isVerified:true }});
+  }
+}
+
+(async ()=>{
+  await upsertAdmin('adminA@khadamat.test','ChangeMe_1!','AdminA');
+  await upsertAdmin('adminB@khadamat.test','ChangeMe_1!','AdminB');
+  console.log('Admins A & B OK');
+  process.exit(0);
+})().catch(e=>{ console.error(e); process.exit(1); });

--- a/backend/scripts/e2e-optionB.sh
+++ b/backend/scripts/e2e-optionB.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE="${BASE:-http://localhost:3000}"
+ROLE="${ROLE:-CLIENT}" # ou PROVIDER
+EMAIL="u$(date +%s)@t.io"
+PASS="Passw0rd!"
+DOCNUM="CINTEST12345678"
+
+echo "== 0) Prépare 2 admins dev =="
+npm run admin:ensure:dev >/dev/null
+
+echo "== 1) Register user ($ROLE) =="
+curl -s -X POST "$BASE/api/auth/register" -H "Content-Type: application/json" \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASS\",\"firstName\":\"Test\",\"lastName\":\"User\",\"role\":\"$ROLE\"}" >/dev/null
+
+echo "== 2) Login user =="
+LOGIN=$(curl -s -X POST "$BASE/api/auth/login" -H "Content-Type: application/json" -d "{\"email\":\"$EMAIL\",\"password\":\"$PASS\"}")
+TOKEN=$(echo "$LOGIN" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{let j=JSON.parse(s);console.log(j.data.tokens.access)}catch{}})")
+USER_ID=$(echo "$LOGIN" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{let j=JSON.parse(s);console.log(j.data.user.id)}catch{}})")
+echo "UserID=$USER_ID"
+
+echo "== 3) Créer session KYC =="
+SESS=$(curl -s -X POST "$BASE/api/kyc/session" -H "Authorization: Bearer $TOKEN")
+EXTERNAL_ID=$(echo "$SESS" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{let j=JSON.parse(s);console.log(j.data.externalId)}catch{}})")
+echo "externalId=$EXTERNAL_ID"
+
+echo "== 4) Simuler webhook verified (avec docNumber) =="
+curl -s -X POST "$BASE/api/kyc/webhook" -H "Content-Type: application/json" \
+  -d "{\"type\":\"identity.verification_session.verified\",\"data\":{\"object\":{\"id\":\"$EXTERNAL_ID\",\"metadata\":{\"userId\":$USER_ID},\"last_verification_report\":{\"document\":{\"type\":\"id_card\"},\"id\":\"rep_1\"},\"docNumber\":\"$DOCNUM\"}}}" >/dev/null
+
+echo "== 5) Vérifier KycVault (chiffré) =="
+npm run -s vault:check -- $USER_ID
+
+echo "== 6) Admin A login =="
+ALOG=$(curl -s -X POST "$BASE/api/auth/login" -H "Content-Type: application/json" -d '{"email":"adminA@khadamat.test","password":"ChangeMe_1!"}')
+ATOK=$(echo "$ALOG" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{let j=JSON.parse(s);console.log(j.data.tokens.access)}catch{}})")
+
+echo "== 7) Admin B login =="
+BLOG=$(curl -s -X POST "$BASE/api/auth/login" -H "Content-Type: application/json" -d '{"email":"adminB@khadamat.test","password":"ChangeMe_1!"}')
+BTOK=$(echo "$BLOG" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{let j=JSON.parse(s);console.log(j.data.tokens.access)}catch{}})")
+
+echo "== 8) Admin A demande disclosure =="
+DR=$(curl -s -X POST "$BASE/api/admin/disclosures" -H "Authorization: Bearer $ATOK" -H "Content-Type: application/json" \
+  -d "{\"targetUserId\":$USER_ID,\"justification\":\"Réquisition de test\"}")
+REQ_ID=$(echo "$DR" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{let j=JSON.parse(s);console.log(j.data.id)}catch{}})")
+echo "requestId=$REQ_ID"
+
+echo "== 9) Admin B approuve =="
+curl -s -X PUT "$BASE/api/admin/disclosures/$REQ_ID/approve" -H "Authorization: Bearer $BTOK" >/dev/null
+
+echo "== 10) Export légal (IP allowlist requis) =="
+EXP=$(curl -s -X GET "$BASE/api/admin/export/$USER_ID?requestId=$REQ_ID" -H "Authorization: Bearer $BTOK")
+echo "$EXP" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{let j=JSON.parse(s);console.log({last4:j.data?.document?.last4, number: j.data?.document?.number})}catch(e){console.log(s)}})"
+
+echo "== 11) (Option) Rotation clé – prépare KYC_ENC_KEYRING_JSON avec k2 et KYC_ENC_ACTIVE_KEY_ID=k2 puis lance le script de ré-encryption si dispo =="
+
+echo "== 12) (Option) Rétention – simule ancienneté et purge =="
+# Exemple: mets à la main updatedAt en DB puis:
+npm run -s kyc:retention:run
+
+echo "OK ✅"

--- a/backend/scripts/run-kyc-retention.ts
+++ b/backend/scripts/run-kyc-retention.ts
@@ -1,0 +1,8 @@
+import { runKycRetentionJob } from '../src/jobs/kycRetention';
+(async () => {
+  await runKycRetentionJob();
+  console.log('KYC retention job done');
+})().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- seed two test admins and add vault/retention helpers
- provide full curl E2E flow script
- sample encryption key and disable admin TOTP in env example

## Testing
- `npm test` *(fails: expected 201 "Created", got 400 "Bad Request")*

------
https://chatgpt.com/codex/tasks/task_e_6897ef1613e4832889b874fc9f61ff66