### PR TITLE
feat: enforce admin MFA

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,6 +14,12 @@ SENTRY_DSN=
 REDIS_URL=
 HEALTH_READY_DELAY_MS=0
 APP_VERSION=0.0.0
+STAGE=dev
+MFA_ENFORCE_ROLES=ADMIN
+MFA_WINDOW_SECONDS=30
+MFA_DRIFT_STEPS=1
+MFA_RATE_LIMIT=5:10m
+MFA_REMEMBER_DAYS=30
 # Notifications web: rien de spécial (DB only)
 
 # --- SMS (activer/désactiver + provider) ---

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -38,6 +38,7 @@ model User {
   pii           UserPII?
   kycVault      KycVault?
   legalHold     LegalHold?
+  mfaSecret      MfaSecret?
 }
 
 model Subscription {
@@ -299,3 +300,17 @@ model LegalHold {
   createdAt DateTime @default(now())
   user      User     @relation(fields: [userId], references: [id])
 }
+
+model MfaSecret {
+  id        Int      @id @default(autoincrement())
+  userId    Int      @unique
+  encSecret Bytes
+  encTag    Bytes
+  encNonce  Bytes
+  keyId     String
+  recoveryCodes String? // JSON array of hashed codes
+  enabledAt DateTime?
+  updatedAt DateTime @updatedAt
+  user      User     @relation(fields: [userId], references: [id])
+}
+

--- a/backend/src/__tests__/mfa.test.ts
+++ b/backend/src/__tests__/mfa.test.ts
@@ -1,0 +1,58 @@
+import '../test/env';
+import request from 'supertest';
+import { app } from '../server';
+import { PrismaClient } from '@prisma/client';
+import { hashPassword } from '../utils/password';
+import { generateSecret, generateTotp } from '../utils/totp';
+import { encryptWithActiveKey } from '../config/keyring';
+
+const prisma = new PrismaClient();
+
+describe('MFA', () => {
+  it('admin login requires mfa and verification works', async () => {
+    process.env.STAGE = 'prod';
+    process.env.MFA_ENFORCE_ROLES = 'ADMIN';
+
+    const email = `admin_${Date.now()}@test.io`;
+    const password = 'Passw0rd!';
+    const hashed = await hashPassword(password);
+    const user = await prisma.user.create({ data: { email, password: hashed, role: 'ADMIN', isVerified: true } });
+
+    const secret = generateSecret();
+    const enc = encryptWithActiveKey(secret);
+    await prisma.mfaSecret.create({
+      data: {
+        userId: user.id,
+        encSecret: enc.encDoc,
+        encTag: enc.encDocTag,
+        encNonce: enc.encDocNonce,
+        keyId: enc.keyId,
+        enabledAt: new Date(),
+        recoveryCodes: '[]',
+      },
+    });
+
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ email, password })
+      .expect(200);
+    expect(loginRes.body.data.mfaRequired).toBe(true);
+    const pending = loginRes.body.data.pendingToken as string;
+    expect(pending).toBeTruthy();
+
+    const code = generateTotp(secret);
+
+    const verifyRes = await request(app)
+      .post('/api/auth/mfa/verify')
+      .set('Authorization', `Bearer ${pending}`)
+      .send({ code })
+      .expect(200);
+    const accessToken = verifyRes.body.data.accessToken;
+    expect(accessToken).toBeTruthy();
+
+    await request(app)
+      .get('/api/stats/admin')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+  });
+});

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -3,11 +3,13 @@ import { PrismaClient } from '@prisma/client';
 import { hashPassword, verifyPassword } from '../utils/password';
 import jwt from 'jsonwebtoken';
 import type { UserRole } from '../middlewares/auth';
+import { decryptWithKeyId } from '../config/keyring';
+import { verifyTotp } from '../utils/totp';
+import crypto from 'node:crypto';
 
 type Role = 'CLIENT' | 'PROVIDER' | 'ADMIN';
 
 const prisma = new PrismaClient();
-
 
 export async function register(req: Request, res: Response, next: NextFunction) {
   try {
@@ -65,6 +67,23 @@ export async function login(req: Request, res: Response, next: NextFunction) {
       return next({ status: 500, message: 'JWT secret not configured' });
     }
 
+    const enforce = process.env.STAGE === 'prod' || process.env.MFA_ENFORCE === 'true';
+    const roles = (process.env.MFA_ENFORCE_ROLES || 'ADMIN').split(',').map((r) => r.trim().toUpperCase());
+    let requireMfa = false;
+    if (enforce && roles.includes(user.role.toUpperCase())) {
+      const mfa = await prisma.mfaSecret.findUnique({ where: { userId: user.id }, select: { enabledAt: true } });
+      if (mfa && mfa.enabledAt) requireMfa = true;
+    }
+
+    if (requireMfa) {
+      const pendingToken = jwt.sign(
+        { id: user.id.toString(), role: user.role.toLowerCase() as UserRole, mfaPending: true },
+        secret,
+        { expiresIn: '5m' }
+      );
+      return res.json({ success: true, data: { mfaRequired: true, pendingToken } });
+    }
+
     const accessToken = jwt.sign(
       { id: user.id.toString(), role: user.role.toLowerCase() as UserRole },
       secret,
@@ -78,6 +97,72 @@ export async function login(req: Request, res: Response, next: NextFunction) {
         user: { id: user.id, email: user.email, role: user.role },
       },
     });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function verifyMfa(req: Request, res: Response, next: NextFunction) {
+  try {
+    const authHeader = req.headers['authorization'];
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({
+        success: false,
+        error: { code: 401, message: 'Authorization header missing or malformed', timestamp: new Date().toISOString() },
+      });
+    }
+    const token = authHeader.split(' ')[1];
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      return next({ status: 500, message: 'JWT secret not configured' });
+    }
+    let payload: any;
+    try {
+      payload = jwt.verify(token, secret);
+    } catch {
+      return res.status(401).json({
+        success: false,
+        error: { code: 401, message: 'Invalid or expired token', timestamp: new Date().toISOString() },
+      });
+    }
+    if (!payload?.mfaPending) {
+      return res.status(400).json({
+        success: false,
+        error: { code: 400, message: 'Invalid pending token', timestamp: new Date().toISOString() },
+      });
+    }
+    const userId = parseInt(payload.id, 10);
+    const { code, recoveryCode } = req.body as { code?: string; recoveryCode?: string };
+    const record = await prisma.mfaSecret.findUnique({ where: { userId } });
+    if (!record || !record.enabledAt) {
+      return res.status(400).json({
+        success: false,
+        error: { code: 400, message: 'MFA not enabled', timestamp: new Date().toISOString() },
+      });
+    }
+    const plain = decryptWithKeyId(record.keyId, record.encSecret, record.encTag, record.encNonce);
+    const step = parseInt(process.env.MFA_WINDOW_SECONDS || '30', 10);
+    const drift = parseInt(process.env.MFA_DRIFT_STEPS || '1', 10);
+    let ok = false;
+    if (code && verifyTotp(code, plain, step, drift)) ok = true;
+    if (!ok && recoveryCode) {
+      const arr = record.recoveryCodes ? (JSON.parse(record.recoveryCodes) as string[]) : [];
+      const hash = crypto.createHash('sha256').update(recoveryCode + (process.env.KYC_HASH_PEPPER || '')).digest('hex');
+      const idx = arr.indexOf(hash);
+      if (idx >= 0) {
+        ok = true;
+        arr.splice(idx, 1);
+        await prisma.mfaSecret.update({ where: { userId }, data: { recoveryCodes: JSON.stringify(arr) } });
+      }
+    }
+    if (!ok) {
+      return res.status(401).json({
+        success: false,
+        error: { code: 401, message: 'Invalid MFA code', timestamp: new Date().toISOString() },
+      });
+    }
+    const accessToken = jwt.sign({ id: userId.toString(), role: payload.role as UserRole, mfa: true }, secret, { expiresIn: '15m' });
+    res.json({ success: true, data: { accessToken } });
   } catch (err) {
     next(err);
   }

--- a/backend/src/controllers/mfaController.ts
+++ b/backend/src/controllers/mfaController.ts
@@ -1,0 +1,82 @@
+import { Request, Response, NextFunction } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { generateSecret, otpauthURL, verifyTotp } from '../utils/totp';
+import { encryptWithActiveKey, decryptWithKeyId } from '../config/keyring';
+import { verifyPassword } from '../utils/password';
+import crypto from 'node:crypto';
+
+const prisma = new PrismaClient();
+
+function hashRecovery(code: string) {
+  const pepper = process.env.KYC_HASH_PEPPER || '';
+  return crypto.createHash('sha256').update(code + pepper).digest('hex');
+}
+
+export async function startSetup(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = parseInt(req.user?.id || '', 10);
+    if (!userId) return next({ status: 401, message: 'Unauthorized' });
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) return next({ status: 404, message: 'User not found' });
+    const secret = generateSecret();
+    const uri = otpauthURL(user.email, secret);
+    const enc = encryptWithActiveKey(secret);
+    await prisma.mfaSecret.upsert({
+      where: { userId },
+      update: { encSecret: enc.encDoc, encTag: enc.encDocTag, encNonce: enc.encDocNonce, keyId: enc.keyId, enabledAt: null, recoveryCodes: null },
+      create: { userId, encSecret: enc.encDoc, encTag: enc.encDocTag, encNonce: enc.encDocNonce, keyId: enc.keyId },
+    });
+    res.json({ success: true, data: { secret, otpauthUrl: uri, qr: null } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function verifySetup(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = parseInt(req.user?.id || '', 10);
+    const { code } = req.body as { code: string };
+    const record = await prisma.mfaSecret.findUnique({ where: { userId } });
+    if (!record) return next({ status: 400, message: 'No setup in progress' });
+    const secret = decryptWithKeyId(record.keyId, record.encSecret, record.encTag, record.encNonce);
+    const step = parseInt(process.env.MFA_WINDOW_SECONDS || '30', 10);
+    const drift = parseInt(process.env.MFA_DRIFT_STEPS || '1', 10);
+    if (!verifyTotp(code, secret, step, drift)) {
+      return next({ status: 400, message: 'Invalid code' });
+    }
+    const codes = Array.from({ length: 10 }, () => crypto.randomBytes(4).toString('hex'));
+    const hashed = codes.map(hashRecovery);
+    await prisma.mfaSecret.update({ where: { userId }, data: { enabledAt: new Date(), recoveryCodes: JSON.stringify(hashed) } });
+    res.json({ success: true, data: { recoveryCodes: codes } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function disableMfa(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = parseInt(req.user?.id || '', 10);
+    const { password, code, recoveryCode } = req.body as { password: string; code?: string; recoveryCode?: string };
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) return next({ status: 404, message: 'User not found' });
+    const validPwd = await verifyPassword(password, user.password);
+    if (!validPwd) return next({ status: 401, message: 'Invalid password' });
+    const record = await prisma.mfaSecret.findUnique({ where: { userId } });
+    if (!record) return next({ status: 400, message: 'MFA not enabled' });
+    const secret = decryptWithKeyId(record.keyId, record.encSecret, record.encTag, record.encNonce);
+    const step = parseInt(process.env.MFA_WINDOW_SECONDS || '30', 10);
+    const drift = parseInt(process.env.MFA_DRIFT_STEPS || '1', 10);
+    let ok = false;
+    if (code && verifyTotp(code, secret, step, drift)) ok = true;
+    if (!ok && recoveryCode) {
+      const arr = record.recoveryCodes ? (JSON.parse(record.recoveryCodes) as string[]) : [];
+      const hash = hashRecovery(recoveryCode);
+      if (arr.includes(hash)) ok = true;
+    }
+    if (!ok) return next({ status: 401, message: 'Invalid code' });
+    await prisma.mfaSecret.delete({ where: { userId } });
+    res.json({ success: true, data: {} });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/middlewares/auth.ts
+++ b/backend/src/middlewares/auth.ts
@@ -6,6 +6,7 @@ export type UserRole = 'client' | 'provider' | 'admin';
 interface JwtPayload {
   id: string;
   role: UserRole;
+  mfa?: boolean;
 }
 
 export function authenticate(req: Request, res: Response, next: NextFunction) {
@@ -29,7 +30,7 @@ export function authenticate(req: Request, res: Response, next: NextFunction) {
     if (!secret) throw new Error('JWT secret not configured');
 
     const decoded = jwt.verify(token, secret) as JwtPayload;
-    req.user = { id: decoded.id, role: decoded.role };
+    req.user = { id: decoded.id, role: decoded.role, mfa: decoded.mfa };
     next();
   } catch {
     return res.status(401).json({
@@ -66,6 +67,7 @@ declare global {
       user?: {
         id: string;
         role: UserRole;
+        mfa?: boolean;
       };
     }
   }

--- a/backend/src/middlewares/rateLimit.ts
+++ b/backend/src/middlewares/rateLimit.ts
@@ -1,8 +1,8 @@
 import rateLimit from 'express-rate-limit';
 
-function createLimiter(max: number, message: string) {
+function createLimiter(max: number, message: string, windowMs = 15 * 60 * 1000) {
   return rateLimit({
-    windowMs: 15 * 60 * 1000,
+    windowMs,
     max,
     standardHeaders: true,
     legacyHeaders: false,
@@ -17,5 +17,22 @@ function createLimiter(max: number, message: string) {
   });
 }
 
+function parseWindow(text: string) {
+  const m = /^(\d+)([smh])?$/.exec(text);
+  if (!m) return 10 * 60 * 1000;
+  const num = parseInt(m[1], 10);
+  const unit = m[2] || 'm';
+  switch (unit) {
+    case 's': return num * 1000;
+    case 'h': return num * 60 * 60 * 1000;
+    default: return num * 60 * 1000;
+  }
+}
+
+const mfaRate = process.env.MFA_RATE_LIMIT || '5:10m';
+const [mfaCount, mfaWindow] = mfaRate.split(':');
+const mfaWindowMs = parseWindow(mfaWindow || '10m');
+
 export const loginLimiter = createLimiter(5, 'Too many login attempts, please try again later.');
 export const paymentsLimiter = createLimiter(100, 'Too many requests, please try again later.');
+export const mfaLimiter = createLimiter(parseInt(mfaCount, 10) || 5, 'Too many MFA attempts, please try again later.', mfaWindowMs);

--- a/backend/src/middlewares/requireMfa.ts
+++ b/backend/src/middlewares/requireMfa.ts
@@ -1,0 +1,25 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function requireMfa(req: Request, res: Response, next: NextFunction) {
+  const enforce = process.env.STAGE === 'prod' || process.env.MFA_ENFORCE === 'true';
+  if (!enforce) return next();
+
+  const roles = (process.env.MFA_ENFORCE_ROLES || 'ADMIN')
+    .split(',')
+    .map((r) => r.trim().toUpperCase())
+    .filter(Boolean);
+  const userRole = req.user?.role?.toUpperCase();
+  if (!userRole || !roles.includes(userRole)) return next();
+
+  if (req.user?.mfa) return next();
+
+  return res.status(403).json({
+    success: false,
+    error: {
+      code: 'MFA_REQUIRED',
+      message: 'Multi-factor authentication required',
+      timestamp: new Date().toISOString(),
+    },
+  });
+}
+

--- a/backend/src/routes/adminDisclosure.ts
+++ b/backend/src/routes/adminDisclosure.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { authenticate, requireRole } from '../middlewares/auth';
+import { requireMfa } from '../middlewares/requireMfa';
 import { ipAllowlist } from '../middlewares/exportGuard';
 import rateLimit from 'express-rate-limit';
 import { createDisclosure, approveDisclosure } from '../controllers/disclosureController';
@@ -8,7 +9,7 @@ import { exportUserEvidence } from '../controllers/legalExportController';
 const router = Router();
 const limiter = rateLimit({ windowMs: 15 * 60 * 1000, max: Number(process.env.KYC_EXPORT_RATE_LIMIT?.split(':')[0] || 5) });
 
-router.use(authenticate, requireRole('admin'), ipAllowlist, limiter);
+router.use(authenticate, requireRole('admin'), requireMfa, ipAllowlist, limiter);
 
 router.post('/disclosures', createDisclosure);
 router.put('/disclosures/:id/approve', approveDisclosure);

--- a/backend/src/routes/mfa.ts
+++ b/backend/src/routes/mfa.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { startSetup, verifySetup, disableMfa } from '../controllers/mfaController';
+import { authenticate } from '../middlewares/auth';
+import { validate } from '../middlewares/validation';
+import { mfaLimiter } from '../middlewares/rateLimit';
+
+const router = Router();
+
+const verifySchema = z.object({
+  body: z.object({ code: z.string() })
+});
+
+const disableSchema = z.object({
+  body: z.object({
+    password: z.string(),
+    code: z.string().optional(),
+    recoveryCode: z.string().optional(),
+  }).refine((d) => d.code || d.recoveryCode, {
+    message: 'code or recoveryCode required',
+  }),
+});
+
+router.post('/setup/start', authenticate, mfaLimiter, startSetup);
+router.post('/setup/verify', authenticate, mfaLimiter, validate(verifySchema), verifySetup);
+router.post('/disable', authenticate, mfaLimiter, validate(disableSchema), disableMfa);
+
+export default router;

--- a/backend/src/routes/stats.ts
+++ b/backend/src/routes/stats.ts
@@ -1,10 +1,11 @@
 import { Router } from 'express';
 import { adminStats, providerStats } from '../controllers/statsController';
 import { authenticate, requireRole } from '../middlewares/auth';
+import { requireMfa } from '../middlewares/requireMfa';
 
 const router = Router();
 
-router.get('/admin', authenticate, requireRole('admin'), adminStats);
+router.get('/admin', authenticate, requireRole('admin'), requireMfa, adminStats);
 router.get('/provider/:providerUserId', authenticate, providerStats);
 
 export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -18,10 +18,12 @@ import smsRouter from './routes/sms';
 import adminRouter from './routes/admin';
 import adminDisclosure from './routes/adminDisclosure';
 import statsRouter from './routes/stats';
+import mfaRouter from './routes/mfa';
 import kycRoutes from './routes/kyc';
 import piiRoutes from './routes/pii';
 import { kycWebhook } from './controllers/kycWebhookController';
 import { authenticate, requireRole } from './middlewares/auth';
+import { requireMfa } from './middlewares/requireMfa';
 import { logger } from './config/logger';
 import { maintenanceGuard } from './middlewares/maintenance';
 import { startSchedulers } from './jobs/scheduler';
@@ -110,6 +112,7 @@ app.get('/ready', (_req, res) => {
 
 app.use(maintenanceGuard);
 
+app.use('/api/mfa', mfaRouter);
 app.use('/api/auth', authRoutes);
 app.use('/api/subscriptions', subscriptionRoutes);
 app.use('/api/payments', paymentRoutes);
@@ -124,7 +127,7 @@ app.use('/api/kyc', kycRoutes);
 app.use('/api/pii', piiRoutes);
 app.use('/api/sms', smsRouter);
 app.use('/api/admin', adminDisclosure);
-app.use('/api/admin', authenticate, requireRole('admin'), adminRouter);
+app.use('/api/admin', authenticate, requireRole('admin'), requireMfa, adminRouter);
 app.use('/api/stats', statsRouter);
 
 app.use(errorHandler);

--- a/backend/src/utils/totp.ts
+++ b/backend/src/utils/totp.ts
@@ -1,0 +1,65 @@
+import crypto from 'node:crypto';
+
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+export function generateSecret(length = 20): string {
+  const buffer = crypto.randomBytes(length);
+  return base32Encode(buffer);
+}
+
+export function base32Encode(buffer: Buffer): string {
+  let bits = '';
+  for (const byte of buffer) {
+    bits += byte.toString(2).padStart(8, '0');
+  }
+  let output = '';
+  for (let i = 0; i < bits.length; i += 5) {
+    const chunk = bits.slice(i, i + 5);
+    if (chunk.length < 5) {
+      output += BASE32_ALPHABET[parseInt(chunk.padEnd(5, '0'), 2)];
+    } else {
+      output += BASE32_ALPHABET[parseInt(chunk, 2)];
+    }
+  }
+  return output;
+}
+
+export function base32Decode(str: string): Buffer {
+  let bits = '';
+  for (const char of str.replace(/=+$/,'')) {
+    const val = BASE32_ALPHABET.indexOf(char.toUpperCase());
+    if (val === -1) continue;
+    bits += val.toString(2).padStart(5, '0');
+  }
+  const bytes: number[] = [];
+  for (let i = 0; i + 8 <= bits.length; i += 8) {
+    bytes.push(parseInt(bits.slice(i, i + 8), 2));
+  }
+  return Buffer.from(bytes);
+}
+
+export function generateTotp(secret: string, step = 30, time = Date.now()): string {
+  const key = base32Decode(secret);
+  const counter = Math.floor(time / (step * 1000));
+  const buffer = Buffer.alloc(8);
+  buffer.writeUInt32BE(0, 0);
+  buffer.writeUInt32BE(counter, 4);
+  const hmac = crypto.createHmac('sha1', key).update(buffer).digest();
+  const offset = hmac[hmac.length - 1] & 0xf;
+  const code = (hmac.readUInt32BE(offset) & 0x7fffffff) % 1000000;
+  return code.toString().padStart(6, '0');
+}
+
+export function verifyTotp(token: string, secret: string, step = 30, window = 1): boolean {
+  const time = Date.now();
+  for (let errorWindow = -window; errorWindow <= window; errorWindow++) {
+    const code = generateTotp(secret, step, time + errorWindow * step * 1000);
+    if (code === token) return true;
+  }
+  return false;
+}
+
+export function otpauthURL(userEmail: string, secret: string, issuer = 'Khadamat'): string {
+  return `otpauth://totp/${encodeURIComponent(issuer)}:${encodeURIComponent(userEmail)}?secret=${secret}&issuer=${encodeURIComponent(issuer)}`;
+}
+


### PR DESCRIPTION
## Summary
- secure TOTP secrets and recovery codes with new `MfaSecret` model
- require MFA for admin routes and add TOTP login flow
- add CLI tests verifying admin MFA workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ff7a89b08328bbb5067d1a5e9f25