### PR TITLE
feat: auth-aware header and review placeholders

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { LanguageProvider, useLanguage } from "@/contexts/LanguageContext";
+import { AuthProvider } from "@/contexts/AuthContext";
 
 // Layout components
 import Header from "@/components/layout/Header";
@@ -122,8 +123,10 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <LanguageProvider>
-          <Toaster />
-          <Router />
+          <AuthProvider>
+            <Toaster />
+            <Router />
+          </AuthProvider>
         </LanguageProvider>
       </TooltipProvider>
     </QueryClientProvider>

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -6,6 +6,8 @@ import Logo from "@/components/ui/Logo";
 import UserProfileMenu from "@/components/ui/UserProfileMenu";
 import { useUnreadMessages } from '@/hooks/use-unread-messages';
 import { Menu, X, AlertTriangle } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function Header() {
   const { t, language } = useLanguage();
@@ -13,9 +15,7 @@ export default function Header() {
   const hasUnread = useUnreadMessages();
   const isRTL = language === 'ar';
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-
-  // Mock user authentication state - à remplacer par votre logique d'auth
-  const isUserLoggedIn = true; // Changez ceci selon votre logique d'authentification
+  const { isAuthenticated, isLoading } = useAuth();
 
   const navigationItems = [
     { href: "/", label: t("nav.home") },
@@ -53,17 +53,25 @@ export default function Header() {
         {/* Actions (Droite) - Desktop */}
         <div className="hidden lg:flex items-center gap-6">
           {/* Menu profil utilisateur ou boutons de connexion */}
-          {!isUserLoggedIn ? (
+          {isLoading ? (
+            <Skeleton className="h-8 w-24" />
+          ) : !isAuthenticated ? (
             <>
               <Link href="/login">
-                <button className="px-3 py-2 text-gray-700 hover:text-orange-500 transition-all font-medium rounded-lg hover:shadow-md hover:bg-orange-50 transform hover:scale-105">
-                  {t("nav.login")}
+                <button
+                  className="px-3 py-2 text-gray-700 hover:text-orange-500 transition-all font-medium rounded-lg hover:shadow-md hover:bg-orange-50 transform hover:scale-105"
+                  aria-label={t("auth.login")}
+                >
+                  {t("auth.login")}
                 </button>
               </Link>
-              
+
               <Link href="/register">
-                <button className="gradient-orange text-white px-4 py-2 rounded-lg font-semibold transition-all transform hover:scale-105 shadow-md">
-                  {t("nav.register")}
+                <button
+                  className="gradient-orange text-white px-4 py-2 rounded-lg font-semibold transition-all transform hover:scale-105 shadow-md"
+                  aria-label={t("auth.signup")}
+                >
+                  {t("auth.signup")}
                 </button>
               </Link>
             </>
@@ -132,22 +140,27 @@ export default function Header() {
                   <LanguageToggle />
                 </div>
                 
-                {!isUserLoggedIn ? (
+                {isLoading ? (
+                  <div className="px-4 py-3 space-y-2">
+                    <Skeleton className="h-4 w-full" />
+                    <Skeleton className="h-4 w-full" />
+                  </div>
+                ) : !isAuthenticated ? (
                   <>
                     <Link
                       href="/login"
                       onClick={() => setIsMobileMenuOpen(false)}
                       className="block px-4 py-3 text-gray-700 hover:text-orange-500 transition-all font-medium rounded-lg hover:bg-orange-50"
                     >
-                      {t("nav.login")}
+                      {t("auth.login")}
                     </Link>
-                    
+
                     <Link
                       href="/register"
                       onClick={() => setIsMobileMenuOpen(false)}
                       className="block px-4 py-3 gradient-orange text-white rounded-lg font-semibold transition-all text-center"
                     >
-                      {t("nav.register")}
+                      {t("auth.signup")}
                     </Link>
                   </>
                 ) : (

--- a/client/src/components/layout/MobileHeader.tsx
+++ b/client/src/components/layout/MobileHeader.tsx
@@ -9,20 +9,25 @@ import {
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import LanguageToggle from "@/components/ui/LanguageToggle";
-import { 
-  Menu, 
-  UserPlus, 
-  LogIn, 
+import {
+  Menu,
+  UserPlus,
+  LogIn,
   AlertTriangle,
   X,
-  Info
+  Info,
+  User
 } from "lucide-react";
 import { Link } from "wouter";
 import logoImage from "@assets/Symbole abstrait sur fond orange_1753291962087.png";
+import { useAuth } from "@/contexts/AuthContext";
+import UserProfileMenu from "@/components/ui/UserProfileMenu";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function MobileHeader() {
   const { t, language } = useLanguage();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const { isAuthenticated, isLoading } = useAuth();
 
   const handleSOSClick = () => {
     // SOS functionality would be implemented here
@@ -35,9 +40,9 @@ export default function MobileHeader() {
       <div className="flex items-center justify-between px-4 py-3">
         {/* Logo and Title */}
         <div className="flex items-center space-x-3">
-          <img 
-            src={logoImage} 
-            alt="Khadamat Logo" 
+          <img
+            src={logoImage}
+            alt="Khadamat Logo"
             className="w-8 h-8 object-contain"
           />
           <h1 className="text-xl font-bold text-gray-900">
@@ -45,48 +50,78 @@ export default function MobileHeader() {
           </h1>
         </div>
 
-        {/* Menu Button */}
-        <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="p-2 text-gray-700 hover:text-orange-600 hover:bg-orange-50"
-            >
-              {isMenuOpen ? (
-                <X className="w-6 h-6" />
-              ) : (
-                <Menu className="w-6 h-6" />
-              )}
-            </Button>
-          </DropdownMenuTrigger>
+        <div className="flex items-center space-x-2">
+          {isLoading ? (
+            <Skeleton className="w-8 h-8 rounded-full" />
+          ) : (
+            isAuthenticated && <UserProfileMenu />
+          )}
+
+          {/* Menu Button */}
+          <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="p-2 text-gray-700 hover:text-orange-600 hover:bg-orange-50"
+              >
+                {isMenuOpen ? (
+                  <X className="w-6 h-6" />
+                ) : (
+                  <Menu className="w-6 h-6" />
+                )}
+              </Button>
+            </DropdownMenuTrigger>
           
-          <DropdownMenuContent 
-            align="end" 
+          <DropdownMenuContent
+            align="end"
             className="w-56 mt-2 bg-white/95 backdrop-blur-md border border-orange-100"
             sideOffset={4}
           >
-            <Link href="/register">
-              <DropdownMenuItem 
-                onClick={() => setIsMenuOpen(false)}
-                className="flex items-center space-x-3 px-4 py-3 hover:bg-orange-50 focus:bg-orange-50"
-              >
-                <UserPlus className="w-5 h-5 text-orange-600" />
-                <span className="font-medium">{t("header.register")}</span>
-              </DropdownMenuItem>
-            </Link>
-            
-            <Link href="/login">
-              <DropdownMenuItem 
-                onClick={() => setIsMenuOpen(false)}
-                className="flex items-center space-x-3 px-4 py-3 hover:bg-orange-50 focus:bg-orange-50"
-              >
-                <LogIn className="w-5 h-5 text-orange-600" />
-                <span className="font-medium">{t("header.login")}</span>
-              </DropdownMenuItem>
-            </Link>
-            
-            <DropdownMenuSeparator className="bg-orange-100" />
+            {isLoading ? (
+              <div className="p-4 space-y-2">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
+            ) : !isAuthenticated ? (
+              <>
+                <Link href="/register">
+                  <DropdownMenuItem
+                    onClick={() => setIsMenuOpen(false)}
+                    className="flex items-center space-x-3 px-4 py-3 hover:bg-orange-50 focus:bg-orange-50"
+                  >
+                    <UserPlus className="w-5 h-5 text-orange-600" />
+                    <span className="font-medium">{t("auth.signup")}</span>
+                  </DropdownMenuItem>
+                </Link>
+
+                <Link href="/login">
+                  <DropdownMenuItem
+                    onClick={() => setIsMenuOpen(false)}
+                    className="flex items-center space-x-3 px-4 py-3 hover:bg-orange-50 focus:bg-orange-50"
+                  >
+                    <LogIn className="w-5 h-5 text-orange-600" />
+                    <span className="font-medium">{t("auth.login")}</span>
+                  </DropdownMenuItem>
+                </Link>
+
+                <DropdownMenuSeparator className="bg-orange-100" />
+              </>
+            ) : (
+              <>
+                <Link href="/profile">
+                  <DropdownMenuItem
+                    onClick={() => setIsMenuOpen(false)}
+                    className="flex items-center space-x-3 px-4 py-3 hover:bg-orange-50 focus:bg-orange-50"
+                  >
+                    <User className="w-5 h-5 text-orange-600" />
+                    <span className="font-medium">{t("nav.profile")}</span>
+                  </DropdownMenuItem>
+                </Link>
+
+                <DropdownMenuSeparator className="bg-orange-100" />
+              </>
+            )}
             
             <Link href="/about">
               <DropdownMenuItem 
@@ -119,8 +154,9 @@ export default function MobileHeader() {
               <span className="font-bold">{t("header.sos")}</span>
             </DropdownMenuItem>
           </DropdownMenuContent>
-        </DropdownMenu>
+          </DropdownMenu>
+        </div>
       </div>
-    </header>
+      </header>
   );
 }

--- a/client/src/components/ui/UserProfileMenu.tsx
+++ b/client/src/components/ui/UserProfileMenu.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { Link, useLocation } from "wouter";
+import { useAuth } from "@/contexts/AuthContext";
 import {
   User,
   Package,
@@ -39,9 +40,8 @@ export default function UserProfileMenu({ className = "" }: UserProfileMenuProps
   const [menuPosition, setMenuPosition] = useState<'right' | 'left'>('right');
   const menuRef = useRef<HTMLDivElement>(null);
   const [, setLocation] = useLocation();
-
-  // Aucune donnée utilisateur par défaut
-  const user: AuthUser | null = JSON.parse('null');
+  const { user } = useAuth();
+  const displayName = user ? `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim() || t("profile.menu.account") : t("profile.menu.account");
 
   // Fermer le menu si on clique en dehors
   useEffect(() => {
@@ -109,23 +109,6 @@ export default function UserProfileMenu({ className = "" }: UserProfileMenuProps
     { label: t("profile.menu.settings"), icon: Settings, href: "/reglages" },
   ];
 
-  if (!user) {
-    return (
-      <Link href="/login">
-        <button
-          className={`flex items-center space-x-2 px-3 py-2 rounded-lg hover:bg-orange-50 transition-all duration-200 ${className}`}
-        >
-          <div className="w-8 h-8 rounded-full bg-gradient-to-br from-orange-100 to-orange-200 flex items-center justify-center shadow-sm">
-            <User className="w-4 h-4 text-orange-600" />
-          </div>
-          <span className="text-sm font-medium text-gray-700 hidden md:block">
-            {t("profile.menu.account")}
-          </span>
-        </button>
-      </Link>
-    );
-  }
-
   return (
     <div className={`relative ${className}`} ref={menuRef}>
       {/* Bouton du menu */}
@@ -151,7 +134,7 @@ export default function UserProfileMenu({ className = "" }: UserProfileMenuProps
 
         {/* Nom de l'utilisateur */}
         <span className="text-sm font-medium text-gray-700 hidden md:block">
-          {user?.firstName} {user?.lastName}
+          {displayName}
         </span>
 
         {/* Icône de flèche */}
@@ -181,7 +164,7 @@ export default function UserProfileMenu({ className = "" }: UserProfileMenuProps
               </div>
               <div>
                 <p className="text-sm font-semibold text-gray-900">
-                  {user?.firstName} {user?.lastName}
+                  {displayName}
                 </p>
                 <p className="text-xs text-gray-500 flex items-center gap-1">
                   {isClient ? (

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+interface User {
+  firstName?: string;
+  lastName?: string;
+  avatar?: string | null;
+}
+
+interface AuthContextValue {
+  user: User | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  isAuthenticated: false,
+  isLoading: true,
+});
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("user_data");
+    if (stored) {
+      try {
+        setUser(JSON.parse(stored));
+      } catch {
+        setUser(null);
+      }
+    }
+    const timer = setTimeout(() => setIsLoading(false), 300);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, isAuthenticated: !!user, isLoading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+

--- a/client/src/contexts/LanguageContext.tsx
+++ b/client/src/contexts/LanguageContext.tsx
@@ -26,6 +26,10 @@ const translations: Record<Language, TranslationDict> = {
     "nav.contact": "Contact",
     "nav.about": "À propos",
     "nav.profile": "Profil",
+
+    // Auth
+    "auth.login": "Connexion",
+    "auth.signup": "Inscription",
     
     // User Profile Menu
     "profile.menu.profile": "Profil",
@@ -89,6 +93,10 @@ const translations: Record<Language, TranslationDict> = {
     "providers.contact": "Contacter",
     "providers.reviews": "avis",
     "providers.view_profile": "Profil",
+
+    // Reviews
+    "reviews.empty.title": "Aucun avis pour le moment",
+    "reviews.empty.subtitle": "Revenez bientôt : de nouveaux avis apparaîtront ici.",
     
     // Chat
     "chat.title": "Messagerie Instantanée",
@@ -425,15 +433,6 @@ const translations: Record<Language, TranslationDict> = {
     "stats.support": "Support",
     
     // Testimonials
-    "testimonials.review1": "Excellent service ! Le prestataire était ponctuel, professionnel et le travail était parfait. Je recommande vivement.",
-    "testimonials.review2": "Très satisfait de la qualité du service. Prix raisonnable et délais respectés. Je ferai appel à nouveau.",
-    "testimonials.review3": "Plateforme très pratique pour trouver des prestataires fiables. L'interface est intuitive et le service client réactif.",
-    "testimonials.user1": "Client 1",
-    "testimonials.user2": "Client 2",
-    "testimonials.user3": "Client 3",
-    "testimonials.city1": "Casablanca",
-    "testimonials.city2": "Rabat",
-    "testimonials.city3": "Marrakech",
     
     // Newsletter
     "newsletter.stay_informed": "Restez informé des nouveautés et des offres dans votre région",
@@ -571,6 +570,10 @@ const translations: Record<Language, TranslationDict> = {
     "nav.contact": "اتصل بنا",
     "nav.about": "حول",
     "nav.profile": "الملف الشخصي",
+
+    // Auth
+    "auth.login": "تسجيل الدخول",
+    "auth.signup": "التسجيل",
     
     // User Profile Menu
     "profile.menu.profile": "الملف الشخصي",
@@ -641,6 +644,10 @@ const translations: Record<Language, TranslationDict> = {
     "providers.contact": "اتصل",
     "providers.reviews": "مراجعة",
     "providers.view_profile": "الملف الشخصي",
+
+    // Reviews
+    "reviews.empty.title": "لا توجد مراجعات حالياً",
+    "reviews.empty.subtitle": "عودوا لاحقاً: ستظهر المراجعات الجديدة هنا.",
     
     // Chat
     "chat.title": "المراسلة الفورية",
@@ -973,15 +980,6 @@ const translations: Record<Language, TranslationDict> = {
     "stats.support": "الدعم",
     
     // Testimonials
-    "testimonials.review1": "خدمة ممتازة! كان مقدم الخدمة دقيقاً ومهنياً والعمل كان مثالياً. أوصي بشدة.",
-    "testimonials.review2": "راضٍ جداً من جودة الخدمة. السعر معقول والمواعيد محترمة. سألجأ مرة أخرى.",
-    "testimonials.review3": "منصة مفيدة جداً للعثور على مقدمي خدمات موثوقين. الواجهة بديهية وخدمة العملاء متجاوبة.",
-    "testimonials.user1": "عميل 1",
-    "testimonials.user2": "عميل 2",
-    "testimonials.user3": "عميل 3",
-    "testimonials.city1": "الدار البيضاء",
-    "testimonials.city2": "الرباط",
-    "testimonials.city3": "مراكش",
     
     // Newsletter
     "newsletter.stay_informed": "ابق على اطلاع بالأخبار والعروض في منطقتك",

--- a/client/src/pages/Index.tsx
+++ b/client/src/pages/Index.tsx
@@ -10,7 +10,7 @@ import { Link } from "wouter";
 import type { Service } from "@shared/schema";
 import { useGeolocation } from "@/hooks/use-geolocation";
 import { useRef, useEffect, useState } from "react";
-import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function Index() {
   const { t, language } = useLanguage();
@@ -23,9 +23,17 @@ export default function Index() {
   const { data: services, isLoading: servicesLoading } = useQuery<Service[]>({
     queryKey: ["/api/services/popular"],
   });
+  interface Review {
+    id: number;
+    name: string;
+    rating: number;
+    comment: string;
+    avatar?: string | null;
+  }
 
-
-
+  const { data: reviews, isLoading: reviewsLoading } = useQuery<Review[]>({
+    queryKey: ["/api/reviews/home"],
+  });
   useEffect(() => {
     const observer = new IntersectionObserver(
       entries => {
@@ -251,71 +259,54 @@ export default function Index() {
           </div>
           
           <div className="grid md:grid-cols-3 gap-8">
-            <div className="bg-white rounded-2xl p-6 md:p-8 shadow-lg" aria-label="Témoignage">
-              <div className="flex items-center mb-4">
-                <img src="/placeholder-avatar.jpg" alt="" className="w-10 h-10 rounded-full mr-3" loading="lazy" decoding="async" />
-                <div>
-                  <div className="font-semibold text-gray-900">{t("testimonials.user1")}</div>
-                  <Badge variant="secondary" className="mt-1">{language === "ar" ? "عميل موثق" : "Client vérifié"}</Badge>
+            {reviewsLoading ? (
+              Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="bg-white rounded-2xl p-6 md:p-8 shadow-lg">
+                  <div className="flex items-center mb-4">
+                    <Skeleton className="w-10 h-10 rounded-full mr-3" />
+                    <div className="flex-1 space-y-2">
+                      <Skeleton className="h-4 w-24" />
+                      <Skeleton className="h-3 w-32" />
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Skeleton className="h-4 w-3/4" />
+                    <Skeleton className="h-4 w-full" />
+                    <Skeleton className="h-4 w-5/6" />
+                  </div>
                 </div>
-              </div>
-              <div className="flex items-center mb-4">
-                <div className="flex space-x-1" aria-label="Note 5 sur 5">
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <Star key={i} aria-hidden="true" className="w-5 h-5 text-yellow-400 fill-current" />
-                  ))}
+              ))
+            ) : reviews && reviews.length > 0 ? (
+              reviews.map((review) => (
+                <div key={review.id} className="bg-white rounded-2xl p-6 md:p-8 shadow-lg">
+                  <div className="flex items-center mb-4">
+                    {review.avatar ? (
+                      <img src={review.avatar} alt="" className="w-10 h-10 rounded-full mr-3" loading="lazy" />
+                    ) : (
+                      <div className="w-10 h-10 rounded-full bg-gray-200 mr-3" />
+                    )}
+                    <div className="font-semibold text-gray-900">{review.name}</div>
+                  </div>
+                  <div className="flex items-center mb-4">
+                    <div className="flex space-x-1" aria-label={`${review.rating} / 5`}>
+                      {Array.from({ length: 5 }).map((_, i) => (
+                        <Star
+                          key={i}
+                          aria-hidden="true"
+                          className={`w-5 h-5 ${i < review.rating ? 'text-yellow-400 fill-current' : 'text-gray-300'}`}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                  <p className="text-gray-700 mb-4 leading-relaxed font-medium">{review.comment}</p>
                 </div>
+              ))
+            ) : (
+              <div className="min-h-[200px] flex flex-col items-center justify-center text-center md:col-span-3">
+                <h3 className="text-lg font-medium text-gray-900 mb-2">{t('reviews.empty.title')}</h3>
+                <p className="text-gray-500">{t('reviews.empty.subtitle')}</p>
               </div>
-              <p className="relative text-gray-700 mb-4 leading-relaxed font-medium">
-                <span className="absolute -left-3 -top-2 text-4xl text-orange-200" aria-hidden="true">“</span>
-                {t("testimonials.review1")}
-                <span className="absolute -right-3 -bottom-4 text-4xl text-orange-200" aria-hidden="true">”</span>
-              </p>
-            </div>
-
-            <div className="bg-white rounded-2xl p-6 md:p-8 shadow-lg" aria-label="Témoignage">
-              <div className="flex items-center mb-4">
-                <img src="/placeholder-avatar.jpg" alt="" className="w-10 h-10 rounded-full mr-3" loading="lazy" decoding="async" />
-                <div>
-                  <div className="font-semibold text-gray-900">{t("testimonials.user2")}</div>
-                  <Badge variant="secondary" className="mt-1">{language === "ar" ? "عميل موثق" : "Client vérifié"}</Badge>
-                </div>
-              </div>
-              <div className="flex items-center mb-4">
-                <div className="flex space-x-1" aria-label="Note 5 sur 5">
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <Star key={i} aria-hidden="true" className="w-5 h-5 text-yellow-400 fill-current" />
-                  ))}
-                </div>
-              </div>
-              <p className="relative text-gray-700 mb-4 leading-relaxed font-medium">
-                <span className="absolute -left-3 -top-2 text-4xl text-orange-200" aria-hidden="true">“</span>
-                {t("testimonials.review2")}
-                <span className="absolute -right-3 -bottom-4 text-4xl text-orange-200" aria-hidden="true">”</span>
-              </p>
-            </div>
-
-            <div className="bg-white rounded-2xl p-6 md:p-8 shadow-lg" aria-label="Témoignage">
-              <div className="flex items-center mb-4">
-                <img src="/placeholder-avatar.jpg" alt="" className="w-10 h-10 rounded-full mr-3" loading="lazy" decoding="async" />
-                <div>
-                  <div className="font-semibold text-gray-900">{t("testimonials.user3")}</div>
-                  <Badge variant="secondary" className="mt-1">{language === "ar" ? "عميل موثق" : "Client vérifié"}</Badge>
-                </div>
-              </div>
-              <div className="flex items-center mb-4">
-                <div className="flex space-x-1" aria-label="Note 5 sur 5">
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <Star key={i} aria-hidden="true" className="w-5 h-5 text-yellow-400 fill-current" />
-                  ))}
-                </div>
-              </div>
-              <p className="relative text-gray-700 mb-4 leading-relaxed font-medium">
-                <span className="absolute -left-3 -top-2 text-4xl text-orange-200" aria-hidden="true">“</span>
-                {t("testimonials.review3")}
-                <span className="absolute -right-3 -bottom-4 text-4xl text-orange-200" aria-hidden="true">”</span>
-              </p>
-            </div>
+            )}
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- show login and signup buttons when unauthenticated with loading skeletons
- display dynamic or placeholder review cards on the homepage
- add auth context and i18n keys for auth actions and empty review state

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68991fe19b588328998c404d7d7c3c0c