### PR TITLE
feat: guard Club Pro checkout with auth

### DIFF
--- a/client/src/contexts/LanguageContext.tsx
+++ b/client/src/contexts/LanguageContext.tsx
@@ -1,4 +1,10 @@
-import { createContext, useContext, useState, useEffect } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  type ReactNode,
+} from "react";
 
 type Language = "fr" | "ar";
 
@@ -30,6 +36,7 @@ const translations: Record<Language, TranslationDict> = {
     // Auth
     "auth.login": "Connexion",
     "auth.signup": "Inscription",
+    "auth.required": "Vous devez être connecté pour continuer",
     "auth.forgot.title": "Mot de passe oublié",
     "auth.forgot.email_label": "Email",
     "auth.forgot.send_link": "Envoyer le lien",
@@ -41,7 +48,10 @@ const translations: Record<Language, TranslationDict> = {
     "auth.reset.success": "Mot de passe mis à jour",
     "auth.reset.token_expired": "Lien expiré, redemandez un e-mail",
     "auth.reset.token_invalid": "Lien invalide",
-    
+
+    // Club
+    "club.join": "Rejoindre le Club Pro",
+
     // User Profile Menu
     "profile.menu.profile": "Profil",
     "profile.menu.orders": "Mes commandes",
@@ -585,6 +595,7 @@ const translations: Record<Language, TranslationDict> = {
     // Auth
     "auth.login": "تسجيل الدخول",
     "auth.signup": "التسجيل",
+    "auth.required": "يجب أن تكون متصلاً للمتابعة",
     "auth.forgot.title": "نسيت كلمة المرور",
     "auth.forgot.email_label": "البريد الإلكتروني",
     "auth.forgot.send_link": "إرسال الرابط",
@@ -596,6 +607,9 @@ const translations: Record<Language, TranslationDict> = {
     "auth.reset.success": "تم تحديث كلمة المرور",
     "auth.reset.token_expired": "انتهت صلاحية الرابط، اطلب بريدًا جديدًا",
     "auth.reset.token_invalid": "الرابط غير صالح",
+
+    // Club
+    "club.join": "انضم إلى كلوب برو",
     
     // User Profile Menu
     "profile.menu.profile": "الملف الشخصي",
@@ -1129,7 +1143,7 @@ const translations: Record<Language, TranslationDict> = {
 
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
 
-export function LanguageProvider({ children }: { children: React.ReactNode }) {
+export function LanguageProvider({ children }: { children: ReactNode }) {
   const [language, setLanguage] = useState<Language>("fr");
 
   useEffect(() => {

--- a/client/src/hooks/useJoinClubPro.ts
+++ b/client/src/hooks/useJoinClubPro.ts
@@ -1,0 +1,19 @@
+import { useAuth } from "@/contexts/AuthContext";
+import { useLocation } from "wouter";
+
+export function useJoinClubPro() {
+  const { isAuthenticated, isLoading } = useAuth();
+  const [, setLocation] = useLocation();
+  const checkoutPath = "/club-pro/checkout";
+
+  const handleJoinClubPro = () => {
+    if (isLoading) return;
+    if (!isAuthenticated) {
+      setLocation(`/login?next=${encodeURIComponent(checkoutPath)}`);
+    } else {
+      setLocation(checkoutPath);
+    }
+  };
+
+  return { handleJoinClubPro, isLoading };
+}

--- a/client/src/pages/ClubPro.tsx
+++ b/client/src/pages/ClubPro.tsx
@@ -3,11 +3,11 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Search, Headphones, Building, Star, CheckCircle, ArrowRight, Users, TrendingUp, Award, CreditCard, Tag, Rocket, Shield, Crown, User, Zap, Target, Calendar, MessageSquare, Phone, Mail, MapPin, Clock, DollarSign, Percent, ArrowUpRight } from "lucide-react";
-import { useLocation } from "wouter";
+import { useJoinClubPro } from "@/hooks/useJoinClubPro";
 
 export default function ClubPro() {
   const { t } = useLanguage();
-  const [, setLocation] = useLocation();
+  const { handleJoinClubPro, isLoading } = useJoinClubPro();
 
   const features = [
     {
@@ -118,13 +118,20 @@ export default function ClubPro() {
             </div>
           </div>
 
-          <Button 
-            variant="outline" 
+          <Button
+            variant="outline"
             className="bg-white text-orange-600 hover:bg-gray-100 px-8 py-4 text-lg font-semibold rounded-xl transition-all transform hover:scale-105 shadow-2xl"
-            onClick={() => setLocation("/club-pro/checkout")}
+            onClick={handleJoinClubPro}
+            disabled={isLoading}
           >
-            {t("club_pro.join_button")}
-            <ArrowRight className="w-5 h-5 ml-2" />
+            {isLoading ? (
+              <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+            ) : (
+              <>
+                {t("club.join")}
+                <ArrowRight className="w-5 h-5 ml-2" />
+              </>
+            )}
           </Button>
         </div>
       </section>
@@ -268,10 +275,17 @@ export default function ClubPro() {
               <div className="text-center">
                 <Button
                 className="w-full bg-white text-orange-600 hover:bg-gray-100 py-4 text-lg font-semibold rounded-xl transition-all transform hover:scale-105 shadow-xl"
-                onClick={() => setLocation("/club-pro/checkout")}
+                onClick={handleJoinClubPro}
+                disabled={isLoading}
               >
-                {t("club_pro.join_now")}
-                <ArrowRight className="w-5 h-5 ml-2" />
+                {isLoading ? (
+                  <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                ) : (
+                  <>
+                    {t("club.join")}
+                    <ArrowRight className="w-5 h-5 ml-2" />
+                  </>
+                )}
               </Button>
                 
                 <p className="text-sm text-orange-100 mt-4">
@@ -352,10 +366,17 @@ export default function ClubPro() {
               <Button
                 variant="outline"
                 className="bg-white text-orange-600 hover:bg-gray-100 px-8 py-4 text-lg font-semibold rounded-xl transition-all transform hover:scale-105 shadow-2xl"
-                onClick={() => setLocation("/club-pro/checkout")}
+                onClick={handleJoinClubPro}
+                disabled={isLoading}
               >
-                {t("club_pro.cta_join")}
-                <ArrowRight className="w-5 h-5 ml-2" />
+                {isLoading ? (
+                  <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                ) : (
+                  <>
+                    {t("club.join")}
+                    <ArrowRight className="w-5 h-5 ml-2" />
+                  </>
+                )}
               </Button>
 
               <Button

--- a/client/src/pages/ClubProCheckout.tsx
+++ b/client/src/pages/ClubProCheckout.tsx
@@ -1,18 +1,21 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { useLocation } from "wouter";
+import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Skeleton } from "@/components/ui/skeleton";
 import { ArrowLeft, CreditCard, Shield, Lock, Crown, CheckCircle, ArrowRight } from "lucide-react";
 
 export default function ClubProCheckout() {
   const { t } = useLanguage();
   const [, setLocation] = useLocation();
-  const [isLoading, setIsLoading] = useState(false);
+  const { isAuthenticated, isLoading: authLoading, user } = useAuth();
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [formData, setFormData] = useState({
     firstName: "",
     lastName: "",
@@ -36,15 +39,42 @@ export default function ClubProCheckout() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setIsLoading(true);
-    
+    setIsSubmitting(true);
+
     // Simulation d'un processus de paiement
     setTimeout(() => {
-      setIsLoading(false);
+      setIsSubmitting(false);
       // Rediriger vers une page de succès ou le profil
       setLocation("/profile");
     }, 2000);
   };
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      setLocation(`/login?next=/club-pro/checkout`);
+    }
+  }, [authLoading, isAuthenticated, setLocation]);
+
+  if (authLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Skeleton className="w-12 h-12 rounded-full" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  if (user && !(user as any).isProvider) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center p-4 text-center space-y-4">
+        <p>{t("auth.required")}</p>
+        <Button onClick={() => setLocation("/register")}>{t("join_providers.become_provider")}</Button>
+      </div>
+    );
+  }
 
   const planDetails = {
     name: "Club Pro",
@@ -241,10 +271,10 @@ export default function ClubProCheckout() {
 
                   <Button
                     type="submit"
-                    disabled={isLoading || !formData.acceptTerms}
+                    disabled={isSubmitting || !formData.acceptTerms}
                     className="w-full bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 text-white py-3 text-lg font-semibold rounded-xl transition-all transform hover:scale-105 shadow-xl"
                   >
-                    {isLoading ? (
+                    {isSubmitting ? (
                       <div className="flex items-center space-x-2">
                         <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
                         <span>Traitement en cours...</span>

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -24,6 +24,7 @@ type LoginFormData = z.infer<typeof loginSchema>;
 export default function Login() {
   const { t, language } = useLanguage();
   const [, setLocation] = useLocation();
+  const nextUrl = new URLSearchParams(window.location.search).get("next") || "/";
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -83,7 +84,7 @@ export default function Login() {
 
       // Redirection après connexion
       setTimeout(() => {
-        setLocation('/');
+        setLocation(nextUrl);
       }, 1500);
 
     } catch (error) {

--- a/client/src/pages/Register.tsx
+++ b/client/src/pages/Register.tsx
@@ -70,6 +70,7 @@ type RegisterFormData = z.infer<typeof registerSchema>;
 export default function Register() {
   const { t } = useLanguage();
   const [, setLocation] = useLocation();
+  const nextUrl = new URLSearchParams(window.location.search).get("next") || "/";
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -167,6 +168,9 @@ export default function Register() {
       }
 
       setSuccess(true);
+      setTimeout(() => {
+        setLocation(nextUrl);
+      }, 1500);
 
     } catch (error) {
       console.error('Erreur inscription:', error);


### PR DESCRIPTION
## Summary
- centralize Club Pro join logic with reusable hook
- protect Club Pro checkout with auth guard and orientation for non-providers
- respect next param after login and signup
- import ReactNode in LanguageProvider to fix type error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68992e25446c8328a320f3c2f2cbaa76