### PR TITLE
fix: adjust Arabic language label

### DIFF
--- a/client/src/contexts/LanguageContext.tsx
+++ b/client/src/contexts/LanguageContext.tsx
@@ -1284,7 +1284,7 @@ const translations: Record<Language, TranslationDict> = {
     "settings.profile_section": "الملف الشخصي والمعلومات",
     "settings.profile.personal": "المعلومات الشخصية",
     "settings.profile.avatar": "الصورة الرمزية والصورة",
-    "settings.profile.language": "تفضيلات اللغة",
+    "settings.profile.language": "إعدادات اللغة",
     "settings.security_section": "الأمان والوصول",
     "settings.security.password": "كلمة المرور",
     "settings.security.2fa": "المصادقة الثنائية",


### PR DESCRIPTION
## Summary
- correct Arabic translation for language option in settings page

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68993a140828832888482e9e82629bcf