### PR TITLE
feat: enhance home smart search

### DIFF
--- a/client/src/pages/Index.tsx
+++ b/client/src/pages/Index.tsx
@@ -11,7 +11,7 @@ import type { Service } from "@shared/schema";
 import { useGeolocation } from "@/hooks/use-geolocation";
 import { useRef, useEffect, useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
-import { getNameBySlug } from "@/lib/servicesCatalog";
+import { getNameBySlug, useServicesCatalog } from "@/lib/servicesCatalog";
 
 export default function Index() {
   const { t, language } = useLanguage();
@@ -19,6 +19,7 @@ export default function Index() {
   const numberFormatter = new Intl.NumberFormat(language);
   const stepsRef = useRef<(HTMLDivElement | null)[]>([]);
   const [showTop, setShowTop] = useState(false);
+  useServicesCatalog();
 
   // Fetch popular services
   const { data: services, isLoading: servicesLoading } = useQuery<Service[]>({


### PR DESCRIPTION
## Summary
- preload service catalog with offline seed fallback
- enrich home smart search with provider counts and slug-based queries
- prefetch catalog on home page mount

## Testing
- `npm test`
- `BASE_URL=http://localhost:5000 npm run e2e:smoke:services`
- `BASE_URL=http://localhost:5000 npm run e2e:smoke:providers`


------
https://chatgpt.com/codex/tasks/task_e_689a9afefb788328898894b13e5d3265