### PR TITLE
feat: add provider search autosuggest and unify scroll button

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,7 +14,7 @@ import Footer from "@/components/layout/Footer";
 import MobileHeader from "@/components/layout/MobileHeader";
 import MobileBottomNav from "@/components/layout/MobileBottomNav";
 import MobileTabBar from "@/components/layout/MobileTabBar";
-import ScrollToTop from "@/components/ui/ScrollToTop";
+import ScrollToTopButton from "@/components/ui/ScrollToTopButton";
 import ScrollManager from "@/components/ui/ScrollManager";
 
 // Pages
@@ -71,7 +71,7 @@ function Router() {
   return (
     <div className="min-h-screen bg-gray-50" dir={language === "ar" ? "rtl" : "ltr"}>
       <ScrollManager />
-      <ScrollToTop />
+      <ScrollToTopButton />
       <Header />
       <MobileHeader />
       <main className="pb-20 md:pb-0">

--- a/client/src/components/providers/ProviderAutocomplete.tsx
+++ b/client/src/components/providers/ProviderAutocomplete.tsx
@@ -1,0 +1,162 @@
+import { useState, useEffect } from "react";
+import { Search } from "lucide-react";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { useLocation } from "wouter";
+
+interface ProviderAutocompleteProps {
+  value: string;
+  onChange: (v: string) => void;
+  city?: string;
+  onSubmit?: () => void;
+}
+
+interface Suggestion {
+  id: string;
+  slug?: string;
+  displayName: string;
+  mainCity?: string;
+  topServices?: string[];
+}
+
+function normalize(str: string) {
+  return str
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[إأآا]/g, "ا")
+    .replace(/ى/g, "ي")
+    .replace(/[ؤئ]/g, "ء")
+    .replace(/ة/g, "ه");
+}
+
+export default function ProviderAutocomplete({
+  value,
+  onChange,
+  city,
+  onSubmit,
+}: ProviderAutocompleteProps) {
+  const { t } = useLanguage();
+  const [, setLocation] = useLocation();
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [show, setShow] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  useEffect(() => {
+    if (!value.trim()) {
+      setSuggestions([]);
+      return;
+    }
+    const controller = new AbortController();
+   const handler = setTimeout(async () => {
+     try {
+       const params = new URLSearchParams({
+         q: normalize(value),
+         limit: "8",
+       });
+       if (city) params.append("city", city);
+        const timeout = setTimeout(() => controller.abort(), 1200);
+        try {
+          const res = await fetch(`/api/providers/suggest?${params.toString()}`, {
+            signal: controller.signal,
+          });
+          const json = await res.json();
+          setSuggestions(json.data?.items || []);
+        } finally {
+          clearTimeout(timeout);
+        }
+      } catch {
+        if (!controller.signal.aborted) setSuggestions([]);
+      }
+    }, 250);
+    return () => {
+      clearTimeout(handler);
+      controller.abort();
+    };
+  }, [value, city]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setShow(true);
+      setActiveIndex((i) => Math.min(i + 1, suggestions.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      if (activeIndex >= 0 && suggestions[activeIndex]) {
+        const p = suggestions[activeIndex];
+        setLocation(`/providers/${p.slug || p.id}`);
+      } else {
+        onSubmit?.();
+      }
+      setShow(false);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
+      <input
+        type="text"
+        placeholder={t("providers.search.byNamePlaceholder")}
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setShow(true);
+          setActiveIndex(-1);
+        }}
+        onFocus={() => setShow(true)}
+        onBlur={() => setTimeout(() => setShow(false), 150)}
+        onKeyDown={handleKeyDown}
+        aria-autocomplete="list"
+        aria-controls="provider-suggestions"
+        aria-activedescendant={
+          activeIndex >= 0 ? `provider-option-${activeIndex}` : undefined
+        }
+        className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+      />
+      {show && value && (
+        <ul
+          id="provider-suggestions"
+          role="listbox"
+          className="absolute left-0 top-full z-10 w-full bg-white border border-gray-200 rounded-b-lg shadow-lg max-h-56 overflow-auto"
+        >
+          {suggestions.length > 0 ? (
+            suggestions.map((p, idx) => (
+              <li
+                key={p.id}
+                id={`provider-option-${idx}`}
+                role="option"
+                aria-selected={activeIndex === idx}
+                className={`px-4 py-2 cursor-pointer hover:bg-orange-50 text-gray-700 ${
+                  activeIndex === idx ? "bg-orange-50" : ""
+                }`}
+                onMouseEnter={() => setActiveIndex(idx)}
+                onMouseDown={() =>
+                  setLocation(`/providers/${p.slug || p.id}`)
+                }
+              >
+                <div className="flex justify-between">
+                  <span>{p.displayName}</span>
+                  {p.mainCity && (
+                    <span className="text-sm text-gray-500">{p.mainCity}</span>
+                  )}
+                </div>
+                {p.topServices && p.topServices.length > 0 && (
+                  <div className="text-sm text-gray-500">
+                    {p.topServices.slice(0, 2).join(", ")}
+                  </div>
+                )}
+              </li>
+            ))
+          ) : (
+            <li className="px-4 py-2 text-gray-700">
+              {t("providers.search.noResults")}
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/ui/ScrollToTopButton.tsx
+++ b/client/src/components/ui/ScrollToTopButton.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { ChevronUp } from "lucide-react";
 import { useLocation } from "wouter";
 
-export default function ScrollToTop() {
+export default function ScrollToTopButton() {
   const [isVisible, setIsVisible] = useState(false);
   const [, setLocation] = useLocation();
 

--- a/client/src/contexts/LanguageContext.tsx
+++ b/client/src/contexts/LanguageContext.tsx
@@ -167,6 +167,8 @@ const translations: Record<Language, TranslationDict> = {
     "providers.contact": "Contacter",
     "providers.reviews": "avis",
     "providers.view_profile": "Profil",
+    "providers.search.byNamePlaceholder": "Nom du prestataire",
+    "providers.search.noResults": "Aucun prestataire trouvé",
 
     // Reviews
     "reviews.empty.title": "Aucun avis pour le moment",
@@ -835,6 +837,8 @@ const translations: Record<Language, TranslationDict> = {
     "providers.contact": "اتصل",
     "providers.reviews": "مراجعة",
     "providers.view_profile": "الملف الشخصي",
+    "providers.search.byNamePlaceholder": "اسم مقدم الخدمة",
+    "providers.search.noResults": "لم يتم العثور على مقدم خدمة",
 
     // Reviews
     "reviews.empty.title": "لا توجد مراجعات حالياً",

--- a/client/src/pages/Index.tsx
+++ b/client/src/pages/Index.tsx
@@ -9,7 +9,7 @@ import { Lightbulb, Search, User, MessageCircle, Star, Wrench, Droplets, Sparkle
 import { Link } from "wouter";
 import type { Service } from "@shared/schema";
 import { useGeolocation } from "@/hooks/use-geolocation";
-import { useRef, useEffect, useState } from "react";
+import { useRef, useEffect } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getNameBySlug, useServicesCatalog } from "@/lib/servicesCatalog";
 
@@ -18,7 +18,6 @@ export default function Index() {
   const { city: userLocation } = useGeolocation();
   const numberFormatter = new Intl.NumberFormat(language);
   const stepsRef = useRef<(HTMLDivElement | null)[]>([]);
-  const [showTop, setShowTop] = useState(false);
   useServicesCatalog();
 
   // Fetch popular services
@@ -54,11 +53,6 @@ export default function Index() {
     return () => observer.disconnect();
   }, []);
 
-  useEffect(() => {
-    const onScroll = () => setShowTop(window.scrollY > 600);
-    window.addEventListener("scroll", onScroll);
-    return () => window.removeEventListener("scroll", onScroll);
-  }, []);
 
   return (
     <div className="min-h-screen">
@@ -325,14 +319,6 @@ export default function Index() {
         </Button>
       </a>
 
-      {/* Back to top button */}
-      <button
-        onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-        className={`fixed bottom-4 right-4 hidden md:flex w-10 h-10 items-center justify-center rounded-full bg-orange-500 text-white transition-opacity ${showTop ? "opacity-100" : "opacity-0 pointer-events-none"}`}
-        aria-label={language === "ar" ? "العودة إلى الأعلى" : "Retour en haut"}
-      >
-        ↑
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable ProviderAutocomplete for provider name suggestions
- replace duplicate home scroll button with shared ScrollToTopButton
- localize provider search strings in French and Arabic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a9e558a388328ad28a047d2fc6ee6