### PR TITLE
feat: handle missing language context

### DIFF
--- a/client/src/contexts/LanguageContext.tsx
+++ b/client/src/contexts/LanguageContext.tsx
@@ -1414,7 +1414,13 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
 export function useLanguage(): LanguageContextType {
   const context = useContext(LanguageContext);
   if (context === undefined) {
-    throw new Error("useLanguage must be used within a LanguageProvider");
+    console.warn("useLanguage called outside of LanguageProvider");
+    return {
+      language: "fr",
+      toggleLanguage: () => {},
+      t: (key: string) => key,
+      isRTL: false,
+    };
   }
   return context;
 }


### PR DESCRIPTION
## Summary
- prevent crash when useLanguage is used outside provider by returning default values

## Testing
- `npm run check` *(fails: Object literal may only specify known properties, and 'city' does not exist; Argument of type 'string | undefined' is not assignable to parameter of type 'string')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aa30dbcd4832893773ce1d93eaac5