### PR TITLE
Guard LanguageProvider against non-browser environments

### DIFF
--- a/client/src/contexts/LanguageContext.tsx
+++ b/client/src/contexts/LanguageContext.tsx
@@ -1367,6 +1367,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   const [language, setLanguage] = useState<Language>("fr");
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
     const savedLanguage = localStorage.getItem("khadamat-language") as Language;
     if (savedLanguage && (savedLanguage === "fr" || savedLanguage === "ar")) {
       setLanguage(savedLanguage);
@@ -1374,10 +1375,11 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
     localStorage.setItem("khadamat-language", language);
     document.documentElement.dir = language === "ar" ? "rtl" : "ltr";
     document.documentElement.lang = language;
-    
+
     if (language === "ar") {
       document.documentElement.classList.add("rtl");
     } else {


### PR DESCRIPTION
## Summary
- ensure `LanguageProvider` only accesses `localStorage` and `document` when `window` is available

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e0c5798f083289497900aba320366