### PR TITLE
feat(search): configurable geo radius and local ranking

### DIFF
--- a/client/src/components/search/SmartSearch.tsx
+++ b/client/src/components/search/SmartSearch.tsx
@@ -105,11 +105,9 @@ export default function SmartSearch({
                 providersCountInCity: map.get(r.item.slug) ?? 0,
               }))
               .sort((a, b) => {
-                if (a.score !== b.score) return a.score - b.score;
-                return (
-                  (b.providersCountInCity > 0 ? 1 : 0) -
-                  (a.providersCountInCity > 0 ? 1 : 0)
-                );
+                if (b.providersCountInCity !== a.providersCountInCity)
+                  return b.providersCountInCity - a.providersCountInCity;
+                return a.score - b.score;
               })
           );
         } finally {
@@ -177,7 +175,7 @@ export default function SmartSearch({
   };
 
   return (
-    <div className={`max-w-4xl mx-auto bg-white rounded-2xl shadow-xl border border-orange-100 p-4 md:p-6 mb-8 md:mb-12 ${className}`}> 
+    <div className={`relative max-w-4xl mx-auto bg-white rounded-2xl shadow-xl border border-orange-100 p-4 md:p-6 mb-8 md:mb-12 ${className}`}>
       <div className="flex flex-col md:flex-row items-stretch md:items-center space-y-3 md:space-y-0 md:space-x-4">
         {/* Service input */}
         <div className="flex items-center space-x-3 px-3 md:px-4 flex-1 border border-gray-200 md:border-none rounded-xl md:rounded-none relative">

--- a/client/src/components/services/ServiceCard.tsx
+++ b/client/src/components/services/ServiceCard.tsx
@@ -16,14 +16,14 @@ export default function ServiceCard({ service, onClick }: ServiceCardProps) {
   const description = language === "ar" && service.descriptionAr ? service.descriptionAr : (service.description || "");
 
   return (
-    <div 
-      className="group bg-white rounded-2xl p-8 shadow-lg border border-gray-100 hover:shadow-2xl hover:border-orange-200 transition-all duration-300 hover-scale cursor-pointer"
+    <div
+      className="group bg-white border-2 border-gray-200 rounded-2xl p-8 text-center hover:shadow-xl hover:border-orange-300 transition-[transform,box-shadow,border-color] duration-300 transform hover:-translate-y-1 shadow-md service-card-pulse cursor-pointer"
       onClick={onClick}
     >
-      <div className="w-16 h-16 bg-white border border-gray-200 rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
+      <div className="mb-6 flex items-center justify-center group-hover:scale-110 transition-transform">
         {(() => {
           const Icon = getServiceIcon(service.category);
-          return <Icon className="w-12 h-12" />;
+          return <Icon className="w-12 h-12 text-orange-500" />;
         })()}
       </div>
       

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,0 +1,9 @@
+import { env } from 'process';
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export const SEARCH_RADIUS_KM = clamp(parseInt(env.SEARCH_RADIUS_KM || '30', 10), 5, 100);
+export type SearchRankingMode = 'popularity_local' | 'text_first';
+export const SEARCH_RANKING: SearchRankingMode = env.SEARCH_RANKING === 'text_first' ? 'text_first' : 'popularity_local';


### PR DESCRIPTION
## Summary
- expose server-side search config for default radius and ranking mode
- rank service and provider suggestions by local popularity ahead of text match
- align Services page cards with home style and scope provider dropdown within search bar

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e75a7c2448328961220a5815b5807