### PR TITLE
feat(auth): refresh rotation, logout blacklist, change/reset password

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -327,3 +327,15 @@ model PasswordResetToken {
   @@index([userId, expiresAt])
 }
 
+model RefreshToken {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  jtiHash   String   @unique
+  expiresAt DateTime
+  revokedAt DateTime?
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, revokedAt])
+}
+

--- a/backend/src/__tests__/auth-flow.test.ts
+++ b/backend/src/__tests__/auth-flow.test.ts
@@ -1,0 +1,44 @@
+import '../test/env';
+import request from 'supertest';
+import { app } from '../server';
+import { PrismaClient } from '@prisma/client';
+import crypto from 'node:crypto';
+
+const prisma = new PrismaClient();
+
+describe('Auth flow', () => {
+  it('login -> refresh -> logout', async () => {
+    const email = `t${Date.now()}_${Math.random().toString(36).slice(2)}@test.io`;
+    await request(app).post('/api/auth/register').send({ email, password: 'Passw0rd!', role: 'CLIENT' }).expect(201);
+    const loginRes = await request(app).post('/api/auth/login').send({ email, password: 'Passw0rd!' }).expect(200);
+    const cookie = loginRes.headers['set-cookie'][0].split(';')[0];
+    const refreshRes = await request(app).post('/api/auth/refresh').set('Cookie', cookie).send({}).expect(200);
+    const newCookie = refreshRes.headers['set-cookie'][0].split(';')[0];
+    await request(app).post('/api/auth/logout').set('Cookie', newCookie).send({}).expect(200);
+  });
+
+  it('change password works', async () => {
+    const email = `c${Date.now()}_${Math.random().toString(36).slice(2)}@test.io`;
+    await request(app).post('/api/auth/register').send({ email, password: 'Passw0rd!', role: 'CLIENT' }).expect(201);
+    const loginRes = await request(app).post('/api/auth/login').send({ email, password: 'Passw0rd!' }).expect(200);
+    const token = loginRes.body.data.accessToken;
+    await request(app)
+      .post('/api/auth/change-password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ oldPassword: 'Passw0rd!', newPassword: 'N3wPassw0rd!' })
+      .expect(200);
+    await request(app).post('/api/auth/login').send({ email, password: 'N3wPassw0rd!' }).expect(200);
+  });
+
+  it('reset password confirm works', async () => {
+    const email = `r${Date.now()}_${Math.random().toString(36).slice(2)}@test.io`;
+    await request(app).post('/api/auth/register').send({ email, password: 'Passw0rd!', role: 'CLIENT' }).expect(201);
+    await request(app).post('/api/auth/reset-password').send({ email }).expect(200);
+    const user = await prisma.user.findUnique({ where: { email } });
+    const raw = crypto.randomBytes(32).toString('hex');
+    const tokenHash = crypto.createHash('sha256').update(raw + (process.env.RESET_TOKEN_PEPPER || '')).digest('hex');
+    await prisma.passwordResetToken.create({ data: { userId: user!.id, tokenHash, expiresAt: new Date(Date.now() + 3600000) } });
+    await request(app).post('/api/auth/reset-password/confirm').send({ token: raw, newPassword: 'NewPass123!' }).expect(200);
+    await request(app).post('/api/auth/login').send({ email, password: 'NewPass123!' }).expect(200);
+  });
+});

--- a/backend/src/middlewares/rateLimit.ts
+++ b/backend/src/middlewares/rateLimit.ts
@@ -38,3 +38,6 @@ export const paymentsLimiter = createLimiter(100, 'Too many requests, please try
 export const mfaLimiter = createLimiter(parseInt(mfaCount, 10) || 5, 'Too many MFA attempts, please try again later.', mfaWindowMs);
 export const forgotPasswordLimiter = createLimiter(3, 'Too many password reset requests, please try again later.');
 export const resetPasswordLimiter = createLimiter(10, 'Too many password reset attempts, please try again later.');
+export const refreshLimiter = createLimiter(20, 'Too many refresh attempts, please try again later.');
+export const logoutLimiter = createLimiter(20, 'Too many logout attempts, please try again later.');
+export const changePasswordLimiter = createLimiter(5, 'Too many password change attempts, please try again later.');

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,9 +1,27 @@
 import { Router } from 'express';
 import { z } from 'zod';
-import { register, login, profile, verifyMfa, forgotPassword, resetPassword } from '../controllers/authController';
+import {
+  register,
+  login,
+  profile,
+  verifyMfa,
+  refresh,
+  logout,
+  changePassword,
+  requestPasswordReset,
+  confirmResetPassword,
+} from '../controllers/authController';
 import { validate } from '../middlewares/validation';
 import { authenticate } from '../middlewares/auth';
-import { loginLimiter, mfaLimiter, forgotPasswordLimiter, resetPasswordLimiter } from '../middlewares/rateLimit';
+import {
+  loginLimiter,
+  mfaLimiter,
+  forgotPasswordLimiter,
+  resetPasswordLimiter,
+  refreshLimiter,
+  logoutLimiter,
+  changePasswordLimiter,
+} from '../middlewares/rateLimit';
 
 const router = Router();
 
@@ -48,23 +66,39 @@ const mfaVerifySchema = z.object({
   }),
 });
 
-const forgotPasswordSchema = z.object({
+const resetRequestSchema = z.object({
   body: z.object({
     email: z.string().email().transform((s) => s.trim().toLowerCase()),
   }),
 });
 
-const resetPasswordSchema = z.object({
+const resetConfirmSchema = z.object({
   body: z.object({
     token: z.string(),
     newPassword: z.string().min(8),
   }),
 });
 
+const changePasswordSchema = z.object({
+  body: z.object({
+    oldPassword: z.string().min(8),
+    newPassword: z.string().min(8),
+  }),
+});
+
+const emptySchema = z.object({
+  body: z.object({}).optional(),
+  params: z.object({}).optional(),
+  query: z.object({}).optional(),
+});
+
 router.post('/register', validate(RegisterSchema), register);
 router.post('/login', loginLimiter, validate(loginSchema), login);
-router.post('/forgot-password', forgotPasswordLimiter, validate(forgotPasswordSchema), forgotPassword);
-router.post('/reset-password', resetPasswordLimiter, validate(resetPasswordSchema), resetPassword);
+router.post('/refresh', refreshLimiter, validate(emptySchema), refresh);
+router.post('/logout', logoutLimiter, validate(emptySchema), logout);
+router.post('/change-password', authenticate, changePasswordLimiter, validate(changePasswordSchema), changePassword);
+router.post('/reset-password', forgotPasswordLimiter, validate(resetRequestSchema), requestPasswordReset);
+router.post('/reset-password/confirm', resetPasswordLimiter, validate(resetConfirmSchema), confirmResetPassword);
 router.post('/mfa/verify', mfaLimiter, validate(mfaVerifySchema), verifyMfa);
 router.get('/profile', authenticate, profile);
 


### PR DESCRIPTION
## Summary
- add persistent refresh token model and secure rotation on login and refresh
- add logout blacklisting, change password, and reset password endpoints with rate limiting
- expand auth tests covering login → refresh → logout and password flows

## Testing
- `npm test` *(fails: prisma: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f39c3a0a483288aaf2aeb213f2988