### PR TITLE
feat: hide provider search bar on home page

### DIFF
--- a/client/src/components/search/SmartSearch.tsx
+++ b/client/src/components/search/SmartSearch.tsx
@@ -130,6 +130,10 @@ export default function SmartSearch({
       : [];
 
   useEffect(() => {
+    if (!showProvider) {
+      setProviderSuggestions([]);
+      return;
+    }
     const controller = new AbortController();
     const handler = setTimeout(async () => {
       if (provider) {
@@ -158,16 +162,16 @@ export default function SmartSearch({
       clearTimeout(handler);
       controller.abort();
     };
-  }, [provider, city]);
+  }, [provider, city, showProvider]);
 
   const handleSearch = () => {
     const params = new URLSearchParams();
     if (selectedService) params.append("services", selectedService.slug);
     if (city) params.append("city", city);
-    if (provider) params.append("q", provider);
+    if (showProvider && provider) params.append("q", provider);
     const url = `/providers${params.toString() ? `?${params.toString()}` : ""}`;
     setLocation(url);
-    onSearch?.(serviceQuery, city, provider);
+    onSearch?.(serviceQuery, city, showProvider ? provider : undefined);
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {

--- a/client/src/pages/Index.tsx
+++ b/client/src/pages/Index.tsx
@@ -89,6 +89,7 @@ export default function Index() {
           <div id="search">
             <SmartSearch
               showSuggestions={true}
+              showProvider={false}
               defaultLocation={city}
               onServiceQueryChange={setSearchQuery}
               onCityChange={(c) => {


### PR DESCRIPTION
## Summary
- add showProvider control in SmartSearch to skip provider name when disabled
- hide provider search bar on home hero

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7c63313988328be9b819c84b329a5