### PR TITLE
feat: add staging online env and token workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ backups
 # Online test environment files
 backend/.env.online.*
 !backend/.env.online.*.example
+backend/.env.tokens.*

--- a/backend/.env.online.staging.example
+++ b/backend/.env.online.staging.example
@@ -1,15 +1,18 @@
 ONLINE_TESTS_ENABLE=true
 BACKEND_BASE_URL=https://api.staging.khadamat.ma
-BACKEND_HEALTH_PATH=/health
-BACKEND_WAIT_TIMEOUT_MS=15000
-BACKEND_WAIT_RETRY_MS=1000
-START_BACKEND_FOR_TESTS=false
-START_BACKEND_CMD=auto
-UPLOAD_DRIVER=auto   # auto | multer | express-fileupload
 
-TEST_PROVIDER_EMAIL=provider.staging@example.com
-TEST_PROVIDER_PASSWORD=Change_me_123!
+# Stripe (staging)
+STRIPE_SECRET_KEY=sk_test_XXXXXXXX
+STRIPE_WEBHOOK_SECRET=whsec_checkout_XXXXXXXX
+STRIPE_IDENTITY_WEBHOOK_SECRET=whsec_identity_XXXXXXXX
 
-STRIPE_SECRET_KEY=sk_test_xxx
-STRIPE_WEBHOOK_SECRET=whsec_checkout_xxx
-STRIPE_IDENTITY_WEBHOOK_SECRET=whsec_identity_xxx
+# Comptes de test staging (créés manuellement dans l’admin)
+TEST_PROVIDER_EMAIL=provider.staging@khadamat.ma
+TEST_PROVIDER_PASSWORD=changeme
+
+# Admin staging (MFA requis)
+ADMIN_EMAIL=admin.staging@khadamat.ma
+ADMIN_PASSWORD=changeme
+# Si MFA: fournir l’un de ces deux (au run)
+# ADMIN_TOTP=123456
+# ADMIN_RECOVERY_CODE=xxxx-xxxx-xxxx

--- a/backend/package.json
+++ b/backend/package.json
@@ -61,11 +61,16 @@
     "online:payments": "node scripts/online/payments.check.js",
     "online:kyc": "node scripts/online/kyc.check.js",
     "online:all": "npm run online:payments && npm run online:kyc",
-
     "online:all:local": "node scripts/env/load.js .env.online.local -- npm run ops:spawn && node scripts/env/load.js .env.online.local -- npm run ops:wait && node scripts/env/load.js .env.online.local -- npm run online:all && node scripts/env/load.js .env.online.local -- npm run ops:kill",
-    "online:all:staging": "node scripts/env/load.js .env.online.staging -- npm run ops:wait && node scripts/env/load.js .env.online.staging -- npm run online:all",
-    "postdeploy:staging": "npm run ops:wait && npm run ops:verify && npm run smoke:all",
-    "postdeploy:staging:online": "npm run ops:wait && npm run online:all:staging",
+
+    "tokens:get:staging": "node scripts/env/load.js backend/.env.online.staging -- node scripts/tokens/get.cjs",
+    "tokens:show:staging": "node -e \"console.log(process.env.ADMIN_BEARER_TOKEN, process.env.PROVIDER_BEARER_TOKEN)\"",
+
+    "online:payments:staging": "node scripts/env/load.js backend/.env.online.staging backend/.env.tokens.staging -- npm run online:payments",
+    "online:kyc:staging": "node scripts/env/load.js backend/.env.online.staging backend/.env.tokens.staging -- npm run online:kyc",
+    "online:all:staging": "node scripts/env/load.js backend/.env.online.staging backend/.env.tokens.staging -- npm run online:all",
+    "postdeploy:staging": "node scripts/env/load.js backend/.env.online.staging backend/.env.tokens.staging -- npm run ops:wait && npm run ops:verify && npm run smoke:all",
+    "postdeploy:staging:online": "node scripts/env/load.js backend/.env.online.staging backend/.env.tokens.staging -- npm run ops:wait && npm run online:all",
     "postdeploy:prod": "npm run ops:wait && npm run ops:go-live",
     "e2e:optionB": "bash scripts/e2e-optionB.sh",
     "prisma:version": "npx prisma --version",

--- a/backend/scripts/env/load.js
+++ b/backend/scripts/env/load.js
@@ -2,24 +2,25 @@ const fs = require('fs');
 const { spawn } = require('child_process');
 
 const args = process.argv.slice(2);
-const envFile = args[0];
 const dashIndex = args.indexOf('--');
+const files = dashIndex === -1 ? args : args.slice(0, dashIndex);
 const cmd = dashIndex === -1 ? [] : args.slice(dashIndex + 1);
 
-if (!fs.existsSync(envFile)) {
-  console.log('SKIPPED (env file not found)');
-  process.exit(0);
-}
-
-const content = fs.readFileSync(envFile, 'utf8');
-for (const line of content.split(/\r?\n/)) {
-  if (!line || line.trim().startsWith('#')) continue;
-  const eq = line.indexOf('=');
-  if (eq === -1) continue;
-  const key = line.slice(0, eq).trim();
-  const value = line.slice(eq + 1).trim();
-  if (process.env[key] === undefined || process.env[key] === '') {
-    process.env[key] = value;
+for (const envFile of files) {
+  if (!fs.existsSync(envFile)) {
+    console.log(`SKIPPED ${envFile}`);
+    continue;
+  }
+  const content = fs.readFileSync(envFile, 'utf8');
+  for (const line of content.split(/\r?\n/)) {
+    if (!line || line.trim().startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (process.env[key] === undefined || process.env[key] === '') {
+      process.env[key] = value;
+    }
   }
 }
 

--- a/backend/scripts/online/kyc.check.js
+++ b/backend/scripts/online/kyc.check.js
@@ -3,7 +3,10 @@ const { fetchJson, logPass, logFail, logSkip, getAuthToken } = require('./util')
 (async () => {
   const name = 'kyc.online';
   try {
-    const required = ['ONLINE_TESTS_ENABLE', 'BACKEND_BASE_URL', 'STRIPE_IDENTITY_WEBHOOK_SECRET', 'TEST_PROVIDER_EMAIL', 'TEST_PROVIDER_PASSWORD'];
+    const required = ['ONLINE_TESTS_ENABLE', 'BACKEND_BASE_URL', 'STRIPE_IDENTITY_WEBHOOK_SECRET'];
+    if (!process.env.PROVIDER_BEARER_TOKEN) {
+      required.push('TEST_PROVIDER_EMAIL', 'TEST_PROVIDER_PASSWORD');
+    }
     const missing = required.filter((k) => !process.env[k]);
     if (missing.length || process.env.ONLINE_TESTS_ENABLE !== 'true') {
       logSkip(name, 'missing ' + missing.join(','));

--- a/backend/scripts/online/payments.check.js
+++ b/backend/scripts/online/payments.check.js
@@ -3,7 +3,10 @@ const { fetchJson, logPass, logFail, logSkip, getAuthToken } = require('./util')
 (async () => {
   const name = 'payments.online';
   try {
-    const required = ['ONLINE_TESTS_ENABLE', 'BACKEND_BASE_URL', 'STRIPE_SECRET_KEY', 'STRIPE_WEBHOOK_SECRET', 'TEST_PROVIDER_EMAIL', 'TEST_PROVIDER_PASSWORD'];
+    const required = ['ONLINE_TESTS_ENABLE', 'BACKEND_BASE_URL', 'STRIPE_SECRET_KEY', 'STRIPE_WEBHOOK_SECRET'];
+    if (!process.env.PROVIDER_BEARER_TOKEN) {
+      required.push('TEST_PROVIDER_EMAIL', 'TEST_PROVIDER_PASSWORD');
+    }
     const missing = required.filter((k) => !process.env[k]);
     if (missing.length || process.env.ONLINE_TESTS_ENABLE !== 'true') {
       logSkip(name, 'missing ' + missing.join(','));

--- a/backend/scripts/online/util.js
+++ b/backend/scripts/online/util.js
@@ -25,6 +25,17 @@ function logSkip(name, reason) {
 }
 
 async function getAuthToken(email, password) {
+  const envToken = process.env.PROVIDER_BEARER_TOKEN;
+  if (envToken) {
+    let payload = {};
+    try {
+      const part = envToken.split('.')[1];
+      const pad = part.padEnd(part.length + (4 - (part.length % 4)) % 4, '=').replace(/-/g, '+').replace(/_/g, '/');
+      payload = JSON.parse(Buffer.from(pad, 'base64').toString('utf8'));
+    } catch {}
+    return { token: envToken, user: { id: payload.id } };
+  }
+  if (!email || !password) return null;
   let login = await fetchJson('POST', '/api/auth/login', { email, password });
   if (!login.success) {
     await fetchJson('POST', '/api/auth/register', { email, password, role: 'PROVIDER' });

--- a/backend/scripts/tokens/get.cjs
+++ b/backend/scripts/tokens/get.cjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const base = process.env.BACKEND_BASE_URL;
+const adminEmail = process.env.ADMIN_EMAIL;
+const adminPassword = process.env.ADMIN_PASSWORD;
+const providerEmail = process.env.TEST_PROVIDER_EMAIL;
+const providerPassword = process.env.TEST_PROVIDER_PASSWORD;
+const outFile = path.join(__dirname, '..', '..', '.env.tokens.staging');
+
+async function postJson(url, body, token) {
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: token } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+    const json = await res.json().catch(() => ({}));
+    return { res, json };
+  } catch (e) {
+    return { error: e };
+  }
+}
+
+async function getProviderToken() {
+  if (!base || !providerEmail || !providerPassword) {
+    return { token: null, reason: 'missing env' };
+  }
+  const { res, json, error } = await postJson(`${base}/api/auth/login`, {
+    email: providerEmail,
+    password: providerPassword,
+  });
+  if (error || !res || !res.ok || !json?.data?.accessToken) {
+    return { token: null, reason: 'login failed' };
+  }
+  return { token: json.data.accessToken };
+}
+
+async function getAdminToken() {
+  if (!base || !adminEmail || !adminPassword) {
+    return { token: null, reason: 'missing env' };
+  }
+  const { res, json, error } = await postJson(`${base}/api/auth/login`, {
+    email: adminEmail,
+    password: adminPassword,
+  });
+  if (error || !res || !res.ok || !json) {
+    return { token: null, reason: 'login failed' };
+  }
+  if (json?.data?.mfaRequired) {
+    const pending = json.data.pendingToken;
+    const totp = process.env.ADMIN_TOTP;
+    const recovery = process.env.ADMIN_RECOVERY_CODE;
+    if (!totp && !recovery) {
+      return { token: null, reason: 'missing mfa' };
+    }
+    const body = totp ? { code: totp } : { recoveryCode: recovery };
+    const { res: vRes, json: vJson, error: vErr } = await postJson(
+      `${base}/api/auth/mfa/verify`,
+      body,
+      pending ? `Bearer ${pending}` : undefined,
+    );
+    if (vErr || !vRes || !vRes.ok || !vJson?.data?.accessToken) {
+      return { token: null, reason: 'mfa failed' };
+    }
+    return { token: vJson.data.accessToken };
+  }
+  if (json?.data?.accessToken) {
+    return { token: json.data.accessToken };
+  }
+  return { token: null, reason: 'login failed' };
+}
+
+(async () => {
+  const admin = await getAdminToken();
+  const provider = await getProviderToken();
+  const lines = [];
+  if (admin.token) lines.push(`ADMIN_BEARER_TOKEN=${admin.token}`);
+  if (provider.token) lines.push(`PROVIDER_BEARER_TOKEN=${provider.token}`);
+  if (lines.length) {
+    try {
+      fs.writeFileSync(outFile, lines.join('\n') + '\n');
+    } catch {}
+  }
+  console.log(admin.token ? 'PASS token:admin' : `SKIPPED token:admin${admin.reason ? ' ' + admin.reason : ''}`);
+  console.log(provider.token ? 'PASS token:provider' : `SKIPPED token:provider${provider.reason ? ' ' + provider.reason : ''}`);
+})();

--- a/docs/RUNBOOK_PROD.md
+++ b/docs/RUNBOOK_PROD.md
@@ -41,3 +41,8 @@
 ## Post-déploiement
 - Après chaque déploiement en production, le pipeline doit appeler `npm run postdeploy:prod`.
 - Ce script exécute la vérification GO-LIVE et doit faire échouer le pipeline en cas de `NO-GO`.
+
+## Post-déploiement Staging
+1. `npm run tokens:get:staging` (définir `ADMIN_TOTP` ou `ADMIN_RECOVERY_CODE` si nécessaire)
+2. `npm run postdeploy:staging`
+3. `npm run postdeploy:staging:online`


### PR DESCRIPTION
## Summary
- ignore online token files and add staging example env
- load multiple env profiles and bootstrap admin/provider tokens
- use pre-fetched tokens in online checks and GO-LIVE gate

## Testing
- `npm --prefix backend test`
- `npm --prefix backend run tokens:get:staging`
- `npm --prefix backend run online:all:staging`
- `npm --prefix backend run ops:go-live`


------
https://chatgpt.com/codex/tasks/task_e_68aa7a15fa948328bf2d9db00ee8681b