### PR TITLE
feat: bootstrap staging env and online token checks

### DIFF
--- a/backend/.env.online.staging.example
+++ b/backend/.env.online.staging.example
@@ -1,18 +1,15 @@
 ONLINE_TESTS_ENABLE=true
 BACKEND_BASE_URL=https://api.staging.khadamat.ma
 
-# Stripe (staging)
 STRIPE_SECRET_KEY=sk_test_XXXXXXXX
 STRIPE_WEBHOOK_SECRET=whsec_checkout_XXXXXXXX
 STRIPE_IDENTITY_WEBHOOK_SECRET=whsec_identity_XXXXXXXX
 
-# Comptes de test staging (créés manuellement dans l’admin)
 TEST_PROVIDER_EMAIL=provider.staging@khadamat.ma
 TEST_PROVIDER_PASSWORD=changeme
 
-# Admin staging (MFA requis)
 ADMIN_EMAIL=admin.staging@khadamat.ma
 ADMIN_PASSWORD=changeme
-# Si MFA: fournir l’un de ces deux (au run)
+# L’un des deux au moment du run :
 # ADMIN_TOTP=123456
 # ADMIN_RECOVERY_CODE=xxxx-xxxx-xxxx

--- a/backend/package.json
+++ b/backend/package.json
@@ -50,22 +50,19 @@
     "smoke:cache": "node scripts/smoke/cache.invalidate.smoke.cjs",
     "smoke:upload": "node scripts/smoke/upload.normalize.smoke.cjs",
     "smoke:all": "npm run smoke:webhooks && npm run smoke:search && npm run smoke:pii && npm run smoke:metrics && npm run smoke:prefs && npm run smoke:subs && npm run smoke:i18n && npm run smoke:cache || true",
-  "ops:wait": "node scripts/ops/wait-backend.js",
-  "ops:verify": "node ../scripts/ops/verify.js",
-  "ops:spawn": "node scripts/ops/spawn-backend.js",
-  "ops:kill": "node scripts/ops/kill-backend.js",
+    "ops:wait": "node scripts/ops/wait-backend.js",
+    "ops:verify": "node ../scripts/ops/verify.js",
+    "ops:spawn": "node scripts/ops/spawn-backend.js",
+    "ops:kill": "node scripts/ops/kill-backend.js",
     "ops:csp-cors": "node scripts/ops/csp-cors.check.js",
     "ops:av-selftest": "node scripts/ops/av-selftest.cjs",
     "ops:go-live": "node scripts/ops/go-live.cjs",
-
     "online:payments": "node scripts/online/payments.check.js",
     "online:kyc": "node scripts/online/kyc.check.js",
     "online:all": "npm run online:payments && npm run online:kyc",
     "online:all:local": "node scripts/env/load.js .env.online.local -- npm run ops:spawn && node scripts/env/load.js .env.online.local -- npm run ops:wait && node scripts/env/load.js .env.online.local -- npm run online:all && node scripts/env/load.js .env.online.local -- npm run ops:kill",
-
     "tokens:get:staging": "node scripts/env/load.js backend/.env.online.staging -- node scripts/tokens/get.cjs",
     "tokens:show:staging": "node -e \"console.log(process.env.ADMIN_BEARER_TOKEN, process.env.PROVIDER_BEARER_TOKEN)\"",
-
     "online:payments:staging": "node scripts/env/load.js backend/.env.online.staging backend/.env.tokens.staging -- npm run online:payments",
     "online:kyc:staging": "node scripts/env/load.js backend/.env.online.staging backend/.env.tokens.staging -- npm run online:kyc",
     "online:all:staging": "node scripts/env/load.js backend/.env.online.staging backend/.env.tokens.staging -- npm run online:all",
@@ -91,7 +88,7 @@
     "setup:windows": "npm run registry:public && npm ci || npm install",
     "setup:mac": "npm run registry:public && npm ci || npm install",
     "doctor": "npm run registry:show && node scripts/check-prisma.js",
-    "tests:setup": "npm run registry:auto && (npm ci || npm install) && npm run test:prepare || (echo \"[tests] install bloquée → exécutez OFFLINE_SKIP_TESTS=true npm test\" && exit 0)",
+    "tests:setup": "npm run registry:auto && (npm ci || npm install) && npm run test:prepare || (echo \"[tests] install bloqu\u00e9e \u2192 ex\u00e9cutez OFFLINE_SKIP_TESTS=true npm test\" && exit 0)",
     "tests:online": "node -e \"process.env.OFFLINE_SKIP_TESTS='false'; process.env.FORCE_ONLINE='true'; require('child_process').spawn('npm', ['run','test'], {stdio:'inherit', shell:true}).on('exit', c=>process.exit(c||0))\"",
     "compose:up": "docker compose up --build",
     "compose:down": "docker compose down -v",
@@ -102,7 +99,10 @@
     "ci:check:local": "node scripts/env/init-online-local.js && node scripts/env/load.js .env.online.local -- npm run ops:spawn && node scripts/env/load.js .env.online.local -- npm run ops:wait && node scripts/env/load.js .env.online.local -- npm run ci:check && node scripts/env/load.js .env.online.local -- npm run ops:kill",
     "ci:check:staging": "node scripts/env/load.js .env.online.staging -- npm run ops:wait && node scripts/env/load.js .env.online.staging -- npm run ci:check",
     "ci:predeploy": "npm run audit:ci && npm run ops:go-live",
-    "audit:schedule": "node scripts/ci/audit-schedule.cjs"
+    "audit:schedule": "node scripts/ci/audit-schedule.cjs",
+    "profiles:init:staging": "node -e \"const fs=require('fs');const p='backend/.env.online.staging';if(fs.existsSync(p)){console.log('SKIPPED: '+p+' exists');process.exit(0)}fs.copyFileSync('backend/.env.online.staging.example',p);console.log('CREATED '+p)\"",
+    "profiles:check:staging": "node scripts/env/load.js backend/.env.online.staging -- node scripts/env/require.cjs backend/.env.online.staging",
+    "tokens:get:staging:all": "node scripts/env/load.js backend/.env.online.staging backend/.env.tokens.staging -- node scripts/tokens/get.cjs"
   },
   "dependencies": {
     "@prisma/client": "5.16.1",

--- a/backend/scripts/env/require.cjs
+++ b/backend/scripts/env/require.cjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+const fs = require('fs');
+
+const files = process.argv.slice(2);
+for (const envFile of files) {
+  if (!fs.existsSync(envFile)) continue;
+  const content = fs.readFileSync(envFile, 'utf8');
+  for (const line of content.split(/\r?\n/)) {
+    if (!line || line.trim().startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (process.env[key] === undefined || process.env[key] === '') {
+      process.env[key] = value;
+    }
+  }
+}
+
+const required = [
+  'ONLINE_TESTS_ENABLE',
+  'BACKEND_BASE_URL',
+  'STRIPE_SECRET_KEY',
+  'STRIPE_WEBHOOK_SECRET',
+  'STRIPE_IDENTITY_WEBHOOK_SECRET',
+  'TEST_PROVIDER_EMAIL',
+  'TEST_PROVIDER_PASSWORD',
+];
+
+const missing = required.filter((k) => !process.env[k]);
+if (missing.length) {
+  console.log('FAIL missing: ' + missing.join(','));
+  process.exit(1);
+}
+console.log('PASS env:staging');

--- a/backend/scripts/online/kyc.check.js
+++ b/backend/scripts/online/kyc.check.js
@@ -1,12 +1,9 @@
-const { fetchJson, logPass, logFail, logSkip, getAuthToken } = require('./util');
+const { fetchJson, logPass, logFail, logSkip, getProviderAuth } = require('./util');
 
 (async () => {
   const name = 'kyc.online';
   try {
-    const required = ['ONLINE_TESTS_ENABLE', 'BACKEND_BASE_URL', 'STRIPE_IDENTITY_WEBHOOK_SECRET'];
-    if (!process.env.PROVIDER_BEARER_TOKEN) {
-      required.push('TEST_PROVIDER_EMAIL', 'TEST_PROVIDER_PASSWORD');
-    }
+    const required = ['ONLINE_TESTS_ENABLE', 'BACKEND_BASE_URL', 'STRIPE_IDENTITY_WEBHOOK_SECRET', 'PROVIDER_BEARER_TOKEN'];
     const missing = required.filter((k) => !process.env[k]);
     if (missing.length || process.env.ONLINE_TESTS_ENABLE !== 'true') {
       logSkip(name, 'missing ' + missing.join(','));
@@ -30,8 +27,11 @@ const { fetchJson, logPass, logFail, logSkip, getAuthToken } = require('./util')
       return;
     }
 
-    const auth = await getAuthToken(process.env.TEST_PROVIDER_EMAIL, process.env.TEST_PROVIDER_PASSWORD);
-    if (!auth) throw new Error('auth failed');
+    const auth = getProviderAuth();
+    if (!auth) {
+      logSkip(name, 'missing PROVIDER_BEARER_TOKEN');
+      return;
+    }
 
     let Stripe;
     try {

--- a/backend/scripts/online/payments.check.js
+++ b/backend/scripts/online/payments.check.js
@@ -1,12 +1,9 @@
-const { fetchJson, logPass, logFail, logSkip, getAuthToken } = require('./util');
+const { fetchJson, logPass, logFail, logSkip, getProviderAuth } = require('./util');
 
 (async () => {
   const name = 'payments.online';
   try {
-    const required = ['ONLINE_TESTS_ENABLE', 'BACKEND_BASE_URL', 'STRIPE_SECRET_KEY', 'STRIPE_WEBHOOK_SECRET'];
-    if (!process.env.PROVIDER_BEARER_TOKEN) {
-      required.push('TEST_PROVIDER_EMAIL', 'TEST_PROVIDER_PASSWORD');
-    }
+    const required = ['ONLINE_TESTS_ENABLE', 'BACKEND_BASE_URL', 'STRIPE_SECRET_KEY', 'STRIPE_WEBHOOK_SECRET', 'PROVIDER_BEARER_TOKEN'];
     const missing = required.filter((k) => !process.env[k]);
     if (missing.length || process.env.ONLINE_TESTS_ENABLE !== 'true') {
       logSkip(name, 'missing ' + missing.join(','));
@@ -30,8 +27,11 @@ const { fetchJson, logPass, logFail, logSkip, getAuthToken } = require('./util')
       return;
     }
 
-    const auth = await getAuthToken(process.env.TEST_PROVIDER_EMAIL, process.env.TEST_PROVIDER_PASSWORD);
-    if (!auth) throw new Error('auth failed');
+    const auth = getProviderAuth();
+    if (!auth) {
+      logSkip(name, 'missing PROVIDER_BEARER_TOKEN');
+      return;
+    }
 
     const sub = await fetchJson('POST', '/api/subscriptions/club-pro', null, auth.token);
     const subscriptionId = sub?.data?.subscription?.id;

--- a/backend/scripts/online/util.js
+++ b/backend/scripts/online/util.js
@@ -24,27 +24,19 @@ function logSkip(name, reason) {
   console.log(`SKIPPED ${name}: ${reason}`);
 }
 
-async function getAuthToken(email, password) {
+function getProviderAuth() {
   const envToken = process.env.PROVIDER_BEARER_TOKEN;
-  if (envToken) {
-    let payload = {};
-    try {
-      const part = envToken.split('.')[1];
-      const pad = part.padEnd(part.length + (4 - (part.length % 4)) % 4, '=').replace(/-/g, '+').replace(/_/g, '/');
-      payload = JSON.parse(Buffer.from(pad, 'base64').toString('utf8'));
-    } catch {}
-    return { token: envToken, user: { id: payload.id } };
-  }
-  if (!email || !password) return null;
-  let login = await fetchJson('POST', '/api/auth/login', { email, password });
-  if (!login.success) {
-    await fetchJson('POST', '/api/auth/register', { email, password, role: 'PROVIDER' });
-    login = await fetchJson('POST', '/api/auth/login', { email, password });
-  }
-  if (login.success) {
-    return { token: login.data.accessToken, user: login.data.user };
-  }
-  return null;
+  if (!envToken) return null;
+  let payload = {};
+  try {
+    const part = envToken.split('.')[1];
+    const pad = part
+      .padEnd(part.length + (4 - (part.length % 4)) % 4, '=')
+      .replace(/-/g, '+')
+      .replace(/_/g, '/');
+    payload = JSON.parse(Buffer.from(pad, 'base64').toString('utf8'));
+  } catch {}
+  return { token: envToken, user: { id: payload.id } };
 }
 
-module.exports = { fetchJson, logPass, logFail, logSkip, getAuthToken };
+module.exports = { fetchJson, logPass, logFail, logSkip, getProviderAuth };

--- a/backend/scripts/ops/go-live.cjs
+++ b/backend/scripts/ops/go-live.cjs
@@ -28,14 +28,12 @@ async function fetchJson(url, opts = {}) {
 (async () => {
   const failures = [];
 
-  const requireTokens = ONLINE_TESTS_ENABLE === 'true';
   if (!ADMIN_BEARER_TOKEN) {
-    if (requireTokens) {
-      log('token', 'FAIL', 'missing ADMIN_BEARER_TOKEN');
-      failures.push('token');
-    } else {
-      log('token', 'WARN', 'missing ADMIN_BEARER_TOKEN');
+    if (ONLINE_TESTS_ENABLE === 'true') {
+      console.log('NO-GO: missing ADMIN_BEARER_TOKEN for admin endpoints.');
+      process.exit(1);
     }
+    log('token', 'WARN', 'missing ADMIN_BEARER_TOKEN');
   }
 
   // Step1: env hardening


### PR DESCRIPTION
## Summary
- add staging env example and validation script
- fetch and store provider/admin tokens from staging backend
- require tokens for online checks and go-live

## Testing
- `npm --prefix backend test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa7c2a13748328a77100c09568b3db