### PR TITLE
feat: harden production env checks

### DIFF
--- a/backend/ops/proxy/nginx.khadamat.example.conf
+++ b/backend/ops/proxy/nginx.khadamat.example.conf
@@ -7,11 +7,13 @@ server {
   # ssl_ciphers can be customised; default modern cipher suites
 
   add_header Strict-Transport-Security "max-age=31536000" always;
+  add_header Content-Security-Policy "default-src 'self';" always;
 
   location /api/ {
     proxy_pass http://localhost:3000;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
     client_max_body_size 20m;
     add_header Cache-Control "no-store";
   }
@@ -20,6 +22,7 @@ server {
     proxy_pass http://localhost:3000;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
     gzip off;
     client_max_body_size 10m;
   }
@@ -28,6 +31,7 @@ server {
     proxy_pass http://localhost:3000;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
     client_max_body_size 10m;
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -56,7 +56,6 @@
     "ops:kill": "node scripts/ops/kill-backend.js",
     "ops:csp-cors": "node scripts/ops/csp-cors.check.js",
     "ops:av-selftest": "node scripts/ops/av-selftest.cjs",
-    "ops:proxy:check": "node scripts/env/load.js backend/.env.production -- node scripts/ops/proxy.check.cjs",
     "ops:dns:check": "node scripts/ops/dns.check.cjs",
     "ops:tls:check": "node scripts/ops/tls.check.cjs",
     "ops:proxy:check": "node scripts/env/load.js ./.env.online.staging -- node scripts/ops/proxy.check.cjs",

--- a/backend/scripts/env/require.prod.cjs
+++ b/backend/scripts/env/require.prod.cjs
@@ -48,6 +48,10 @@ if (missing.length) {
   console.log('FAIL missing: ' + missing.join(','));
   process.exit(1);
 }
+if (!process.env.ADMIN_IP_ALLOWLIST || !process.env.ADMIN_IP_ALLOWLIST.trim()) {
+  console.log('FAIL admin:ip-allowlist');
+  process.exit(1);
+}
 if (process.env.TRUST_PROXY !== 'true') {
   console.log('FAIL trust:proxy');
   process.exit(1);
@@ -61,7 +65,7 @@ if (process.env.COOKIE_SECURE !== 'true') {
   process.exit(1);
 }
 const hsts = parseInt(process.env.HSTS_MAX_AGE, 10);
-if (!Number.isInteger(hsts) || hsts <= 0) {
+if (!Number.isInteger(hsts) || hsts < 31536000) {
   console.log('FAIL hsts:max-age');
   process.exit(1);
 }

--- a/backend/scripts/ops/alerts.check.cjs
+++ b/backend/scripts/ops/alerts.check.cjs
@@ -7,10 +7,11 @@ if (GO_LIVE_REQUIRE_ALERTS_RULES !== 'true') {
   process.exit(0);
 }
 try {
-  const dir = path.resolve(__dirname, '../../ops/alerts');
-  const has = fs.existsSync(dir) && fs.readdirSync(dir).some((f) => f.endsWith('.yml'));
-  if (has) {
+  const file = path.resolve(__dirname, '../../ops/alerts/rules.example.yml');
+  if (fs.existsSync(file)) {
     console.log('PASS alerts:rules');
+  } else if (process.env.ALERTS_ENDPOINT) {
+    console.log('PASS alerts:endpoint');
   } else {
     console.log('FAIL alerts:rules');
     process.exit(1);


### PR DESCRIPTION
## Summary
- enforce admin IP allowlist and minimum HSTS duration in production env validator
- tighten nginx proxy template with CSP and forwarded host headers
- validate presence of alert rules or endpoint before go-live

## Testing
- `npm --prefix backend run ops:dns:check`
- `npm --prefix backend run ops:tls:check`
- `npm --prefix backend run ops:proxy:check`
- `npm --prefix backend run ops:jobs:check`
- `npm --prefix backend run ops:dlq:check`
- `npm --prefix backend run ops:webhooks:verify`
- `npm --prefix backend run ops:backup:now`
- `npm --prefix backend run ops:restore:dryrun`
- `npm --prefix backend run ops:alerts:check`
- `npm --prefix backend run ops:av:selftest`
- `npm --prefix backend run postdeploy:prod`


------
https://chatgpt.com/codex/tasks/task_e_68ab5be61afc8328b2e71b5b4eb43973