### PR TITLE
harden env loading and webhook security

### DIFF
--- a/backend/.env.local.example
+++ b/backend/.env.local.example
@@ -1,0 +1,6 @@
+NODE_ENV=development
+FRONTEND_URL=http://localhost:5173
+COOKIE_SECURE=false
+COOKIE_SAMESITE=lax
+STRIPE_WEBHOOK_SECRET=whsec_dev_only
+STRIPE_IDENTITY_WEBHOOK_SECRET=whsec_identity_dev_only

--- a/backend/.npmrc
+++ b/backend/.npmrc
@@ -1,7 +1,6 @@
 # Registre principal
 registry=https://registry.npmjs.org/
 strict-ssl=true
-always-auth=false
 
 # Forcer @prisma/* sur un miroir compatible
 @prisma:registry=https://registry.npmmirror.com/

--- a/backend/package.json
+++ b/backend/package.json
@@ -137,6 +137,8 @@
     "audit:full": "node scripts/env/load.js ./.env -- node scripts/audit/full.cjs",
     "audit:online": "node scripts/env/load.js ./.env.online.staging ./.env.tokens.staging -- node scripts/audit/full.cjs --online",
     "remediate": "node scripts/remediate/run.cjs",
+    "profiles:dev:ensure": "node scripts/env/load.js ./.env -- node -e \"console.log('ENV OK')\"",
+    "webhooks:check:secrets": "node scripts/env/load.js ./.env -- node -e \"console.log('stripe:', !!process.env.STRIPE_WEBHOOK_SECRET, 'identity:', !!process.env.STRIPE_IDENTITY_WEBHOOK_SECRET)\"",
     "remediate:p0": "node scripts/remediate/run.cjs --level=P0",
     "remediate:p1": "node scripts/remediate/run.cjs --level=P1 --quick",
     "verify:postfix": "npm run audit:full && node scripts/audit/print-last.cjs"

--- a/backend/prisma/migrations/20250824224000_add_webhookevent_idempotence/migration.sql
+++ b/backend/prisma/migrations/20250824224000_add_webhookevent_idempotence/migration.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "WebhookEvent" (
+  "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+  "provider" TEXT NOT NULL,
+  "eventId" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'PROCESSED',
+  "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "processedAt" DATETIME,
+  CONSTRAINT "uq_webhook_provider_event" UNIQUE("provider","eventId")
+);
+
+CREATE INDEX IF NOT EXISTS "idx_webhook_created" ON "WebhookEvent"("createdAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -400,13 +400,12 @@ model WebhookEvent {
   id          Int      @id @default(autoincrement())
   provider    String
   eventId     String
-  type        String?
-  status      String?
+  status      String   @default("PROCESSED")
   createdAt   DateTime @default(now())
   processedAt DateTime?
 
-  @@unique([provider, eventId], map: "uniq_provider_event")
-  @@index([createdAt])
+  @@unique([provider, eventId], map: "uq_webhook_provider_event")
+  @@index([createdAt], map: "idx_webhook_created")
 }
 
 model WebhookDLQ {

--- a/backend/scripts/env/load.js
+++ b/backend/scripts/env/load.js
@@ -7,7 +7,7 @@ const dashIndex = args.indexOf('--');
 const beforeDash = dashIndex === -1 ? args : args.slice(0, dashIndex);
 const cmd = dashIndex === -1 ? [] : args.slice(dashIndex + 1);
 
-let files = [];
+const files = [];
 for (let i = 0; i < beforeDash.length; i++) {
   const a = beforeDash[i];
   if (a === '--env-file') {
@@ -22,21 +22,14 @@ for (let i = 0; i < beforeDash.length; i++) {
   }
 }
 
-if (files.length === 0) {
-  const prod = path.resolve('backend/.env.production');
-  const local = path.resolve('backend/.env');
-  if (fs.existsSync(prod)) files.push(prod);
-  else if (fs.existsSync(local)) files.push(local);
-  else console.log('SKIPPED no env');
-}
-
-const loaded = [];
-for (const envFile of files) {
-  if (!fs.existsSync(envFile)) {
-    console.log(`SKIPPED ${envFile}`);
+let loaded = 0;
+for (const f of files) {
+  const abs = path.resolve(f);
+  if (!fs.existsSync(abs)) {
+    console.log(`FALLBACK ${f}`);
     continue;
   }
-  const content = fs.readFileSync(envFile, 'utf8');
+  const content = fs.readFileSync(abs, 'utf8');
   for (const line of content.split(/\r?\n/)) {
     if (!line || line.trim().startsWith('#')) continue;
     const eq = line.indexOf('=');
@@ -47,10 +40,36 @@ for (const envFile of files) {
       process.env[key] = value;
     }
   }
-  loaded.push(envFile);
+  loaded++;
+  console.log(`ENV LOADED FROM ${f}`);
 }
-if (loaded.length) console.log('ENV LOADED:', loaded.join(' '));
+
+if (!loaded) {
+  const fallbacks = ['./.env', './.env.local', './.env.local.example'];
+  for (const f of fallbacks) {
+    const abs = path.resolve(f);
+    if (fs.existsSync(abs)) {
+      const content = fs.readFileSync(abs, 'utf8');
+      for (const line of content.split(/\r?\n/)) {
+        if (!line || line.trim().startsWith('#')) continue;
+        const eq = line.indexOf('=');
+        if (eq === -1) continue;
+        const key = line.slice(0, eq).trim();
+        const value = line.slice(eq + 1).trim();
+        if (process.env[key] === undefined || process.env[key] === '') {
+          process.env[key] = value;
+        }
+      }
+      loaded++;
+      console.log(`ENV LOADED FROM ${f}`);
+      break;
+    } else {
+      console.log(`FALLBACK ${f}`);
+    }
+  }
+  if (!loaded) console.log('NO ENV FILE LOADED');
+}
 
 if (cmd.length === 0) process.exit(0);
-const child = spawn(cmd[0], cmd.slice(1), { stdio: 'inherit', shell: true });
+const child = spawn(cmd[0], cmd.slice(1), { stdio: 'inherit' });
 child.on('exit', (code) => process.exit(code ?? 0));

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -158,7 +158,7 @@ export function validateEnv() {
   if (env.mockRedis) missing.push('MOCK_REDIS');
   if (env.mockStripe) missing.push('MOCK_STRIPE');
   if (process.env.DEMO_ENABLE === 'true') missing.push('DEMO_ENABLE');
-  if (!env.cookieSecure || !['lax', 'strict'].includes(env.cookieSameSite)) {
+  if (!env.cookieSecure || env.cookieSameSite !== 'strict') {
     missing.push('COOKIE_SECURE/SAMESITE');
   }
 

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -13,7 +13,7 @@ import { env } from '../config/env';
 type Role = 'CLIENT' | 'PROVIDER' | 'ADMIN';
 
 const refreshExpireMs = 7 * 24 * 60 * 60 * 1000;
-const secureCookie = env.cookieSecure && process.env.NODE_ENV === 'production';
+const secureCookie = env.cookieSecure;
 const sameSite = env.cookieSameSite;
 
 function signTokens(userId: number, role: string, mfa?: boolean) {

--- a/backend/src/controllers/kycWebhookController.ts
+++ b/backend/src/controllers/kycWebhookController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { prisma } from '../lib/prisma';
+import { prisma, dbAvailable } from '../lib/prisma';
 import { hashDocNumber, last4 } from '../utils/kycCrypto';
 import { encryptWithActiveKey } from '../config/keyring';
 import { logAction } from '../middlewares/audit';
@@ -9,65 +9,54 @@ import { logger } from '../config/logger';
 import { webhooksProcessedTotal } from '../metrics';
 import { enqueueWebhookDLQ } from '../services/dlq';
 
-function parseEvent(req: any) {
-  const body = req.body;
-  if (Buffer.isBuffer(body)) {
-    try {
-      return JSON.parse(body.toString('utf8'));
-    } catch {
-      return null;
-    }
-  }
-  if (typeof body === 'string') {
-    try {
-      return JSON.parse(body);
-    } catch {
-      return null;
-    }
-  }
-  return body;
-}
-
 // A monter avec express.raw() AVANT json (comme Stripe payments)
 export const kycWebhook = async (req: Request, res: Response) => {
+  const sig = req.headers['stripe-signature'];
+  let event: any;
+  let rawPayload: any;
   try {
-    let event: any;
-    if (env.stripeIdentityWebhookSecret) {
-      const sig = req.headers['stripe-signature'];
-      try {
-        event = stripe.webhooks.constructEvent(req.body, sig as string, env.stripeIdentityWebhookSecret);
-      } catch (err: any) {
-        logger.error('kyc webhook signature invalid', { error: err.message });
-        return res.status(400).json({
-          success: false,
-          error: { code: 'WEBHOOK_SIGNATURE_INVALID', message: 'Invalid signature', timestamp: new Date().toISOString() },
-        });
-      }
-    } else {
-      logger.warn('kyc webhook without signature');
-      event = parseEvent(req);
-    }
-    if (!event) return res.status(400).json({ success: false, error: { code: 'INVALID_PAYLOAD', message: 'invalid_payload', timestamp: new Date().toISOString() } });
-    const type = event?.type;
-    const sess = event?.data?.object;
-    const userId = Number(sess?.metadata?.userId);
-    if (!userId || !type) return res.status(400).json({ success: false, error: { code: 'BAD_REQUEST', message: 'bad_request', timestamp: new Date().toISOString() } });
+    rawPayload = JSON.parse(req.body.toString('utf8'));
+    event = stripe.webhooks.constructEvent(req.body, sig as string, env.stripeIdentityWebhookSecret);
+  } catch (err: any) {
+    logger.error('kyc webhook signature invalid', { error: err.message });
+    return res.status(400).json({
+      success: false,
+      error: { code: 'WEBHOOK_SIGNATURE_INVALID', message: 'Invalid signature', timestamp: new Date().toISOString() },
+    });
+  }
+  const type = event?.type;
+  const sess = event?.data?.object;
+  const userId = Number(sess?.metadata?.userId);
+  if (!userId || !type)
+    return res.status(400).json({
+      success: false,
+      error: { code: 'BAD_REQUEST', message: 'bad_request', timestamp: new Date().toISOString() },
+    });
 
-    try {
-      await prisma.webhookEvent.create({ data: { provider: 'kyc', eventId: event.id, type, status: 'processing' } });
-    } catch {
+  if (dbAvailable) {
+    const existing = await prisma.webhookEvent.findUnique({
+      where: { provider_eventId: { provider: 'kyc', eventId: event.id } },
+    });
+    if (existing) {
       logger.warn('kyc webhook duplicate', { eventId: event.id });
       webhooksProcessedTotal?.inc({ provider: 'kyc', outcome: 'replayed' });
       return res.json({ received: true });
     }
+  } else {
+    logger.warn('SKIP idempotence (db disabled)');
+  }
 
+  try {
     if (type.endsWith('.verified')) {
       const documentType = sess?.last_verification_report?.document?.type || sess?.type || 'id_card';
       const docNumber: string | null = null; // mettre la vraie source si dispo
       const data: any = { reportId: sess?.last_verification_report?.id };
 
       const updates: any = {
-        status: 'VERIFIED', documentType, verifiedAt: new Date(), data
+        status: 'VERIFIED',
+        documentType,
+        verifiedAt: new Date(),
+        data,
       };
 
       if (docNumber) {
@@ -79,7 +68,7 @@ export const kycWebhook = async (req: Request, res: Response) => {
           await prisma.kycVault.upsert({
             where: { userId },
             create: { userId, encDoc, encDocTag, encDocNonce, keyId },
-            update: { encDoc, encDocTag, encDocNonce, keyId }
+            update: { encDoc, encDocTag, encDocNonce, keyId },
           });
         }
       }
@@ -87,43 +76,35 @@ export const kycWebhook = async (req: Request, res: Response) => {
       await prisma.verification.upsert({
         where: { externalId: sess.id },
         update: updates,
-        create: { userId, provider: 'stripe', externalId: sess.id, ...updates }
+        create: { userId, provider: 'stripe', externalId: sess.id, ...updates },
       });
 
       await logAction({ userId, action: 'KYC_VERIFIED', resource: 'verification', resourceId: userId });
-      await prisma.webhookEvent.update({
-        where: { provider_eventId: { provider: 'kyc', eventId: event.id } },
-        data: { status: 'processed', processedAt: new Date() },
-      });
-      webhooksProcessedTotal?.inc({ provider: 'kyc', outcome: 'ok' });
-      return res.json({ received: true });
-    }
-
-    if (type.endsWith('.requires_input') || type.endsWith('.canceled')) {
+    } else if (type.endsWith('.requires_input') || type.endsWith('.canceled')) {
       await prisma.verification.updateMany({
-        where: { externalId: sess.id }, data: { status: 'REJECTED' }
+        where: { externalId: sess.id },
+        data: { status: 'REJECTED' },
       });
       await logAction({ userId, action: 'KYC_REJECTED', resource: 'verification', resourceId: userId });
-      await prisma.webhookEvent.update({
-        where: { provider_eventId: { provider: 'kyc', eventId: event.id } },
-        data: { status: 'processed', processedAt: new Date() },
-      });
-      webhooksProcessedTotal?.inc({ provider: 'kyc', outcome: 'ok' });
-      return res.json({ received: true });
     }
 
-    await prisma.webhookEvent.update({
-      where: { provider_eventId: { provider: 'kyc', eventId: event.id } },
-      data: { status: 'ignored', processedAt: new Date() },
-    });
+    if (dbAvailable) {
+      await prisma.webhookEvent.create({
+        data: { provider: 'kyc', eventId: event.id, status: 'PROCESSED', processedAt: new Date() },
+      });
+    }
+    webhooksProcessedTotal?.inc({ provider: 'kyc', outcome: 'ok' });
     return res.json({ received: true });
   } catch (e: any) {
-    await prisma.webhookEvent.update({
-      where: { provider_eventId: { provider: 'kyc', eventId: (e as any)?.id || '' } },
-      data: { status: 'failed', processedAt: new Date() },
-    }).catch(() => {});
+    if (dbAvailable) {
+      await prisma.webhookEvent
+        .create({
+          data: { provider: 'kyc', eventId: event.id, status: 'FAILED', processedAt: new Date() },
+        })
+        .catch(() => {});
+    }
     webhooksProcessedTotal?.inc({ provider: 'kyc', outcome: 'fail' });
-    await enqueueWebhookDLQ('kyc', parseEvent(req), String(e?.message || e)).catch(() => {});
+    await enqueueWebhookDLQ('kyc', rawPayload || event, String(e?.message || e)).catch(() => {});
     return res.json({ received: true });
   }
 };

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -47,6 +47,8 @@ import { startDlqRunner } from './jobs/dlqRunner';
 
 let dbConnected = false;
 
+logger.info(`cookies: secure=${env.cookieSecure} samesite=${env.cookieSameSite}`);
+
 if (dbAvailable) {
   prisma
     .$connect()
@@ -195,6 +197,7 @@ app.get('/health', async (_req, res) => {
     dlqInfo.smsBacklog = await prisma.smsDLQ.count().catch(() => 0);
   }
   const jobs = getJobsStatus();
+  const webhookSecretsOk = !!env.stripeWebhookSecret && !!env.stripeIdentityWebhookSecret;
   res.json({
     success: true,
     data: {
@@ -204,6 +207,7 @@ app.get('/health', async (_req, res) => {
       av: { enabled: avEnabled, reachable: avReachable },
       dlq: dlqInfo,
       jobs,
+      webhookSecretsOk,
     },
   });
 });


### PR DESCRIPTION
## Summary
- add local env example and robust env loader with fallback search
- enforce secure cookies and log configuration at boot
- verify and de-duplicate Stripe/KYC webhooks with persistent `WebhookEvent`

## Testing
- `npm --prefix backend run profiles:dev:ensure`
- `npm --prefix backend run webhooks:check:secrets`
- `npm --prefix backend run audit:full`


------
https://chatgpt.com/codex/tasks/task_e_68ab91d9442c8328be7922280fe1416e